### PR TITLE
ci: 给 sh 脚本加下执行权限

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -209,6 +209,10 @@ jobs:
               find . -type f -name "MFAUpdater*" -exec chmod +x {} \; 2>/dev/null || true
               echo "Set execute permission for all MFAUpdater files"
               
+              # Set execute permissions for shell scripts
+              find . -type f -name "*.sh" -exec chmod +x {} \; 2>/dev/null || true
+              echo "Set execute permission for all .sh files"
+              
               # Create tar.gz with preserved permissions
               tar -cpzf ../MFAAvalonia-${{ needs.meta.outputs.tag }}-${f}.tar.gz .
               echo "Created archive with preserved permissions: MFAAvalonia-${{ needs.meta.outputs.tag }}-${f}.tar.gz"


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 更新 Release 工作流，在创建归档之前对所有 `.sh` 文件执行 `chmod` 操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update Release workflow to chmod all .sh files before creating archives.

</details>