### PR TITLE
ci: check owner for mirrorchyan

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -244,6 +244,7 @@ jobs:
           TOKEN: ${{ secrets.MFA_TOKEN }}
 
       - name: Trigger MirrorChyanUploading
+        if: ${{ github.repository_owner == 'SweetSmellFox' }}
         run: |
           gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan
           gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release_note

--- a/.github/workflows/mirrorchyan.yml
+++ b/.github/workflows/mirrorchyan.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   mirrorchyan:
+    if: ${{ github.repository_owner == 'SweetSmellFox' }}
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -14,7 +15,6 @@ jobs:
 
     steps:
       - uses: MirrorChyan/uploading-action@v1
-        if: ${{ github.repository_owner == 'SweetSmellFox' }}
         with:
           filetype: latest-release
           filename: ${{ matrix.os == 'win' && format('MFAAvalonia-*-{0}-{1}.zip', matrix.os, matrix.arch) || format('MFAAvalonia-*-{0}-{1}.tar.gz', matrix.os, matrix.arch) }}

--- a/.github/workflows/mirrorchyan_release_note.yml
+++ b/.github/workflows/mirrorchyan_release_note.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   mirrorchyan:
+    if: ${{ github.repository_owner == 'SweetSmellFox' }}
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
## 由 Sourcery 生成的摘要

将与 MirrorChyan 相关的工作流及其触发步骤限制为仅在仓库所有者为 “SweetSmellFox” 时运行，并在适用的情况下将所有者检查集中到作业级别。

CI：
- 将 `mirrorchyan` 和 `mirrorchyan_release_note` 工作流限制为仅在仓库所有者为 “SweetSmellFox” 时运行。
- 确保在 Release 工作流中，MirrorChyan 上传触发步骤仅在仓库所有者为 “SweetSmellFox” 时运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict MirrorChyan-related workflows and triggering steps to run only when the repository owner is 'SweetSmellFox', centralizing the owner check at the job level where applicable.

CI:
- Gate the mirrorchyan and mirrorchyan_release_note workflows to run only when the repository owner is 'SweetSmellFox'.
- Ensure the MirrorChyan uploading trigger step in the Release workflow runs only when the repository owner is 'SweetSmellFox'.

</details>