### PR TITLE
docs: 增加有关在模板项目中自动安装的说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,20 @@ _基于 [Avalonia UI](https://github.com/AvaloniaUI/Avalonia)
 
 ## 🚀 快速开始
 
+本项目是 [MaaFramework](https://github.com/MaaXYZ/MaaFramework) 通用 GUI 解决方案，使用前请务必确保您对 [MaaFramework](https://github.com/MaaXYZ/MaaFramework) 有基本的了解，并且至少已经**完成**了_一个阶段_的[开发工作](https://github.com/MaaXYZ/MaaPracticeBoilerplate/blob/main/docs/zh_cn/develop/how_to_develop.md)。**不要在开发阶段使用本项目进行调试，你应该使用专门的[调试工具](https://github.com/MaaXYZ/MaaFramework/#%E5%BC%80%E5%8F%91%E5%B7%A5%E5%85%B7)**
+
 ### 方式一：自动安装（推荐）
 
-MaaFramework 项目模板已内置 MFAAvalonia，创建项目时自动配置完成。
+MaaFramework [项目模板](https://github.com/MaaXYZ/MaaPracticeBoilerplate/)已内置 MFAAvalonia 的自动配置工具。
+
+有关自动安装的方法请**仔细阅读**[项目模板]的[如何开发](https://github.com/MaaXYZ/MaaPracticeBoilerplate/blob/main/docs/zh_cn/develop/how_to_develop.md)文档。
 
 ### 方式二：手动安装
  
 <details>
 <summary><b>📦 点击展开安装步骤</b></summary>
+
+**绝大多数情况下，你不应该手动安装。**
 
 1. **下载发行版**
 
@@ -344,6 +350,3 @@ MFAAvalonia -c 配置名称
 [![Star History Chart](https://api.star-history.com/svg?repos=MaaXYZ/MFAAvalonia&type=Date)](https://star-history.com/#MaaXYZ/MFAAvalonia&Date)
 
 </div>
-
-
-

--- a/README_en.md
+++ b/README_en.md
@@ -81,14 +81,20 @@ with [Avalonia UI](https://github.com/AvaloniaUI/Avalonia)_
 
 ## 🚀 Quick Start
 
+This project is a universal GUI solution for [MaaFramework](https://github.com/MaaXYZ/MaaFramework). Before using, please make sure you have a basic understanding of [MaaFramework](https://github.com/MaaXYZ/MaaFramework) and have completed at least one stage of [development work](https://github.com/MaaXYZ/MaaPracticeBoilerplate/blob/main/README.md). **Do not use this project for debugging during development; use the dedicated [debugging tools](https://github.com/MaaXYZ/MaaFramework/blob/main/README_en.md#development-tool) instead.**
+
 ### Option 1: Automatic Installation (Recommended)
 
-MaaFramework project templates come with MFAAvalonia pre-configured.
+MaaFramework [project templates](https://github.com/MaaXYZ/MaaPracticeBoilerplate/) come with MFAAvalonia auto-configuration built-in.
+
+For automatic installation, please **carefully read** the [How to Develop](https://github.com/MaaXYZ/MaaPracticeBoilerplate/blob/main/README.md) documentation of the project template.
 
 ### Option 2: Manual Installation
 
 <details>
 <summary><b>📦 Click to expand installation steps</b></summary>
+
+**In most cases, you should not install manually.**
 
 1. **Download Release**
    Download the latest version from [Releases](https://github.com/MaaXYZ/MFAAvalonia/releases) and extract
@@ -249,7 +255,7 @@ The new protocol matches by message type and renders to logs.
 {
   "focus": {
     "Node.Action.Starting": "Start: {name}",
-    "Node.Action.Succeeded": "Done: {name}, [color:green]",
+    "Node.Action.Succeeded": "Done: {name}",
     "Node.Action.Failed": "Failed ID: {action_id}"
   }
 }
@@ -309,7 +315,7 @@ MFAAvalonia -c config-name
 
 ### Custom Icon
 
-Place `logo.ico` in the program root directory to replace the window icon.
+Place `logo.ico` in the `Assets` folder under the program root directory to replace the window icon.
 
 ## 📄 License
 
@@ -344,6 +350,4 @@ Thanks to all developers who contributed to MFAAvalonia!
 
 [![Star History Chart](https://api.star-history.com/svg?repos=MaaXYZ/MFAAvalonia&type=Date)](https://star-history.com/#MaaXYZ/MFAAvalonia&Date)
 
-</div> 
-
-
+</div>


### PR DESCRIPTION
## Summary by Sourcery

在英文和中文的 README 文档中，澄清 MFAAvalonia 的使用场景以及安装指引。

Documentation:
- 在英文和中文文档中说明：MFAAvalonia 是用于 MaaFramework 的通用 GUI 解决方案，不应作为开发调试工具使用。
- 在英文和中文文档中强调：MaaFramework 项目模板已包含对 MFAAvalonia 的自动配置，并引导用户查阅模板的开发文档以完成自动安装。
- 在各 README 文件的安装章节中强调：一般不推荐使用手动安装方式。
- 在英文 README 中更新自定义图标放置说明，改为使用程序根目录下的 Assets 文件夹。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify MFAAvalonia usage context and installation guidance in both English and Chinese readme documents.

Documentation:
- Explain that MFAAvalonia is a universal GUI solution for MaaFramework and should not be used as a development debugging tool, in both English and Chinese docs.
- Highlight that MaaFramework project templates include automatic configuration for MFAAvalonia and direct users to the template’s development documentation for automatic installation, in both English and Chinese docs.
- Emphasize that manual installation is generally not recommended in the installation sections of the readme files.
- Update the description of custom icon placement to use the Assets folder under the program root directory in the English readme.

</details>