### PR TITLE
[codex] add macOS controller support

### DIFF
--- a/MFAAvalonia/Assets/Localization/Strings.en-US.resx
+++ b/MFAAvalonia/Assets/Localization/Strings.en-US.resx
@@ -984,6 +984,9 @@
     <data name="TabWin32" xml:space="preserve">
         <value>Win32</value>
     </data>
+    <data name="TabMacOS" xml:space="preserve">
+        <value>macOS</value>
+    </data>
     <data name="TabPlayCover" xml:space="preserve">
         <value>PlayCover</value>
     </data>

--- a/MFAAvalonia/Assets/Localization/Strings.ja-JP.resx
+++ b/MFAAvalonia/Assets/Localization/Strings.ja-JP.resx
@@ -1330,6 +1330,9 @@
   <data name="TabWin32" xml:space="preserve">
         <value>Win32</value>
     </data>
+  <data name="TabMacOS" xml:space="preserve">
+        <value>macOS</value>
+    </data>
   <data name="TabPlayCover" xml:space="preserve">
         <value>プレイカバー</value>
     </data>

--- a/MFAAvalonia/Assets/Localization/Strings.resx
+++ b/MFAAvalonia/Assets/Localization/Strings.resx
@@ -993,6 +993,9 @@
     <data name="TabWin32" xml:space="preserve">
         <value>桌面应用</value>
     </data>
+    <data name="TabMacOS" xml:space="preserve">
+        <value>macOS</value>
+    </data>
     <data name="TabPlayCover" xml:space="preserve">
         <value>PlayCover</value>
     </data>

--- a/MFAAvalonia/Assets/Localization/Strings.zh-Hant.resx
+++ b/MFAAvalonia/Assets/Localization/Strings.zh-Hant.resx
@@ -984,6 +984,9 @@
     <data name="TabWin32" xml:space="preserve">
         <value>桌面應用</value>
     </data>
+    <data name="TabMacOS" xml:space="preserve">
+        <value>macOS</value>
+    </data>
     <data name="TabPlayCover" xml:space="preserve">
         <value>PlayCover</value>
     </data>

--- a/MFAAvalonia/Extensions/MaaFW/MaaControllerTypes.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaControllerTypes.cs
@@ -8,6 +8,7 @@ public enum MaaControllerTypes
     Adb = 2,
     PlayCover = 4,
     Gamepad = 8,
+    MacOS = 16,
 }
 
 public static class MaaControllerHelper
@@ -22,6 +23,7 @@ public static class MaaControllerHelper
                 MaaControllerTypes.Adb => "TabADB",
                 MaaControllerTypes.PlayCover => "TabPlayCover",
                 MaaControllerTypes.Gamepad => "TabGamepad",
+                MaaControllerTypes.MacOS => "TabMacOS",
                 _ => "TabADB"
             };
         }
@@ -33,6 +35,7 @@ public static class MaaControllerHelper
                 MaaControllerTypes.Adb => "adb",
                 MaaControllerTypes.PlayCover => "playcover",
                 MaaControllerTypes.Gamepad => "gamepad",
+                MaaControllerTypes.MacOS => "macos",
                 _ => "adb"
             };
         }
@@ -46,6 +49,8 @@ public static class MaaControllerHelper
             return MaaControllerTypes.PlayCover;
         if (type.Contains("gamepad", StringComparison.OrdinalIgnoreCase))
             return MaaControllerTypes.Gamepad;
+        if (type.Contains("macos", StringComparison.OrdinalIgnoreCase))
+            return MaaControllerTypes.MacOS;
         if (type.Contains("win32", StringComparison.OrdinalIgnoreCase))
             return MaaControllerTypes.Win32;
         if (type.Contains("adb", StringComparison.OrdinalIgnoreCase))

--- a/MFAAvalonia/Extensions/MaaFW/MaaInterface.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaInterface.cs
@@ -920,6 +920,18 @@ public partial class MaaInterface
         public object? ScreenCap { get; set; }
     }
 
+    public class MaaResourceControllerMacOS
+    {
+        [JsonProperty("class_regex")]
+        public string? ClassRegex { get; set; }
+        [JsonProperty("window_regex")]
+        public string? WindowRegex { get; set; }
+        [JsonProperty("input")]
+        public object? Input { get; set; }
+        [JsonProperty("screencap")]
+        public object? ScreenCap { get; set; }
+    }
+
     /// <summary>
     /// Gamepad 控制器的具体配置（仅 Windows）。
     /// 用于创建虚拟游戏手柄进行游戏控制。需要安装 ViGEm Bus Driver。
@@ -1027,6 +1039,8 @@ public partial class MaaInterface
         public MaaResourceControllerPlayCover? PlayCover { get; set; }
         [JsonProperty("gamepad")]
         public MaaResourceControllerGamepad? Gamepad { get; set; }
+        [JsonProperty("macos")]
+        public MaaResourceControllerMacOS? MacOS { get; set; }
 
         /// <summary>显示名称（用于 UI 绑定）</summary>
         [ObservableProperty] [JsonIgnore] private string _displayName = string.Empty;

--- a/MFAAvalonia/Extensions/MaaFW/MaaMacOSController.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaMacOSController.cs
@@ -1,0 +1,64 @@
+using MaaFramework.Binding;
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using MaaBindingController = MaaFramework.Binding.MaaController;
+using static MaaFramework.Binding.Interop.Native.MaaController;
+
+namespace MFAAvalonia.Extensions.MaaFW;
+
+public enum MacOSScreencapMethod : ulong
+{
+    None = 0,
+    ScreenCaptureKit = 1,
+}
+
+public enum MacOSInputMethod : ulong
+{
+    None = 0,
+    GlobalEvent = 1,
+    PostToPid = 1 << 1,
+}
+
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public class MaaMacOSController : MaaBindingController
+{
+    private readonly DesktopWindowInfo _debugInfo;
+    private readonly MacOSScreencapMethod _debugScreencapMethod;
+    private readonly MacOSInputMethod _debugInputMethod;
+
+    [ExcludeFromCodeCoverage(Justification = "Debugger display.")]
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => IsInvalid
+        ? $"Invalid {GetType().Name}"
+        : $"{GetType().Name} {{ {nameof(_debugInfo.Name)} = {_debugInfo.Name}, {nameof(_debugInfo.ClassName)} = {_debugInfo.ClassName}, ScreencapMethod = {_debugScreencapMethod}, InputMethod = {_debugInputMethod} }}";
+
+    public MaaMacOSController(
+        DesktopWindowInfo info,
+        MacOSScreencapMethod screencapMethod = MacOSScreencapMethod.ScreenCaptureKit,
+        MacOSInputMethod inputMethod = MacOSInputMethod.GlobalEvent,
+        LinkOption link = LinkOption.Start,
+        CheckStatusOption check = CheckStatusOption.ThrowIfNotSucceeded)
+    {
+        ArgumentNullException.ThrowIfNull(info);
+        if (info.Handle == nint.Zero) throw new ArgumentException("Value cannot be zero.", nameof(info.Handle));
+        var rawWindowId = (nuint)info.Handle;
+        if (rawWindowId > uint.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(info.Handle), info.Handle, "macOS window id must fit in UInt32.");
+
+        var handle = MaaMacOSControllerCreate((uint)rawWindowId, screencapMethod, inputMethod);
+        _ = MaaControllerAddSink(handle, MaaEventCallback, (nint)MaaHandleType.Controller);
+        SetHandle(handle, needReleased: true);
+
+        _debugInfo = info;
+        _debugScreencapMethod = screencapMethod;
+        _debugInputMethod = inputMethod;
+
+        if (link == LinkOption.Start)
+            LinkStartOnConstructed(check, info);
+    }
+
+    [DllImport("MaaFramework", EntryPoint = "MaaMacOSControllerCreate")]
+    private static extern nint MaaMacOSControllerCreate(uint windowId, MacOSScreencapMethod screencapMethod, MacOSInputMethod inputMethod);
+}

--- a/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
@@ -1952,6 +1952,23 @@ public class MaaProcessor
 
                 return new MaaPlayCoverController(Config.PlayCover.PlayCoverAddress, Config.PlayCover.UUID);
 
+            case MaaControllerTypes.MacOS:
+                if (logConfig)
+                {
+                    LoggerHelper.Info("当前控制器类型：MacOS");
+                    LoggerHelper.Info($"窗口名称：{Config.DesktopWindow.Name}");
+                    LoggerHelper.Info($"窗口句柄：{Config.DesktopWindow.HWnd}");
+                    LoggerHelper.Info($"截图模式：{Config.MacOSWindow.ScreenCap}");
+                    LoggerHelper.Info($"输入模式：{Config.MacOSWindow.Input}");
+                }
+
+                return new MaaMacOSController(
+                    new DesktopWindowInfo(Config.DesktopWindow.HWnd, Config.DesktopWindow.Name, string.Empty),
+                    Config.MacOSWindow.ScreenCap,
+                    Config.MacOSWindow.Input,
+                    Config.MacOSWindow.Link,
+                    Config.MacOSWindow.Check);
+
             case MaaControllerTypes.Gamepad:
                 // Gamepad 控制器使用 Win32 控制器的配置，但会创建虚拟手柄
                 if (logConfig)

--- a/MFAAvalonia/Extensions/MaaFW/MaaProcessorConfig.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaProcessorConfig.cs
@@ -9,6 +9,7 @@ public class MaaFWConfiguration
 {
     public AdbDeviceCoreConfig AdbDevice { get; set; } = new();
     public DesktopWindowCoreConfig DesktopWindow { get; set; } = new();
+    public MacOSWindowCoreConfig MacOSWindow { get; set; } = new();
     
     public PlayCoverCoreConfig  PlayCover { get; set; } = new();
 }
@@ -49,4 +50,15 @@ public class PlayCoverCoreConfig
     public string Name { get; set; } = string.Empty;
     public string PlayCoverAddress { get; set; } = "";
     public string UUID { get; set; } = "maa.playcover";
+}
+
+/// <summary>
+/// macOS 原生窗口核心配置
+/// </summary>
+public class MacOSWindowCoreConfig
+{
+    public MacOSScreencapMethod ScreenCap { get; set; } = MacOSScreencapMethod.ScreenCaptureKit;
+    public MacOSInputMethod Input { get; set; } = MacOSInputMethod.GlobalEvent;
+    public LinkOption Link { get; set; } = LinkOption.Start;
+    public CheckStatusOption Check { get; set; } = CheckStatusOption.ThrowIfNotSucceeded;
 }

--- a/MFAAvalonia/ViewModels/Pages/TaskQueueViewModel.cs
+++ b/MFAAvalonia/ViewModels/Pages/TaskQueueViewModel.cs
@@ -353,6 +353,9 @@ public partial class TaskQueueViewModel : ViewModelBase
         if (type.Contains("playcover", StringComparison.OrdinalIgnoreCase))
             return OperatingSystem.IsMacOS();
 
+        if (type.Contains("macos", StringComparison.OrdinalIgnoreCase))
+            return OperatingSystem.IsMacOS();
+
         return true;
     }
 
@@ -395,6 +398,14 @@ public partial class TaskQueueViewModel : ViewModelBase
             };
             playCoverController.InitializeDisplayName();
             controllers.Add(playCoverController);
+
+            var macOSController = new MaaInterface.MaaResourceController
+            {
+                Name = "MacOS",
+                Type = MaaControllerTypes.MacOS.ToJsonKey()
+            };
+            macOSController.InitializeDisplayName();
+            controllers.Add(macOSController);
         }
         return controllers;
     }
@@ -1528,7 +1539,7 @@ public partial class TaskQueueViewModel : ViewModelBase
             MaaControllerTypes.PlayCover => false,
             MaaControllerTypes.Adb => CurrentDevice is not AdbDeviceInfo adbInfo
                 || string.IsNullOrWhiteSpace(adbInfo.AdbSerial),
-            MaaControllerTypes.Win32 or MaaControllerTypes.Gamepad => CurrentDevice is not DesktopWindowInfo window
+            MaaControllerTypes.Win32 or MaaControllerTypes.Gamepad or MaaControllerTypes.MacOS => CurrentDevice is not DesktopWindowInfo window
                 || window.Handle == IntPtr.Zero,
             _ => CurrentDevice == null,
         };
@@ -1663,7 +1674,7 @@ public partial class TaskQueueViewModel : ViewModelBase
             ToastHelper.Info(GetDetectionMessage(controllerType));
         SetConnected(false);
         token.ThrowIfCancellationRequested();
-        var (devices, index) = isAdb ? DetectAdbDevices(strictLaunchTarget) : DetectWin32Windows();
+        var (devices, index) = isAdb ? DetectAdbDevices(strictLaunchTarget) : DetectDesktopWindows(controllerType);
         token.ThrowIfCancellationRequested();
         UpdateDeviceList(devices, index);
         token.ThrowIfCancellationRequested();
@@ -1782,20 +1793,22 @@ public partial class TaskQueueViewModel : ViewModelBase
         return parts.Length == 2 && int.TryParse(parts[1], out port);
     }
 
-    private (ObservableCollection<object> devices, int index) DetectWin32Windows()
+    private (ObservableCollection<object> devices, int index) DetectDesktopWindows(MaaControllerTypes controllerType)
     {
         Thread.Sleep(500);
         var windows = MaaProcessor.Toolkit.Desktop.Window.Find().Where(win => !string.IsNullOrWhiteSpace(win.Name)).ToList();
-        var (index, filtered) = CalculateWindowIndex(windows);
+        var (index, filtered) = CalculateWindowIndex(windows, controllerType);
         return (new(filtered), index);
     }
 
-    private (int index, List<DesktopWindowInfo> afterFiltered) CalculateWindowIndex(List<DesktopWindowInfo> windows)
+    private (int index, List<DesktopWindowInfo> afterFiltered) CalculateWindowIndex(List<DesktopWindowInfo> windows, MaaControllerTypes controllerType)
     {
         var controller = MaaProcessor.Interface?.Controller?
-            .FirstOrDefault(c => c.Type?.Equals("win32", StringComparison.OrdinalIgnoreCase) == true);
+            .FirstOrDefault(c => c.Type?.Equals(controllerType.ToJsonKey(), StringComparison.OrdinalIgnoreCase) == true);
 
-        if (controller?.Win32 == null)
+        if (controllerType == MaaControllerTypes.MacOS && controller?.MacOS == null
+            || controllerType == MaaControllerTypes.Gamepad && controller?.Gamepad == null
+            || controllerType == MaaControllerTypes.Win32 && controller?.Win32 == null)
         {
             var idx = MatchPreviousWindow(windows);
             return (idx >= 0 ? idx : Math.Max(0, windows.FindIndex(win => !string.IsNullOrWhiteSpace(win.Name))), windows);
@@ -1804,7 +1817,12 @@ public partial class TaskQueueViewModel : ViewModelBase
         var filtered = windows.Where(win =>
             !string.IsNullOrWhiteSpace(win.Name)).ToList();
 
-        filtered = ApplyRegexFilters(filtered, controller.Win32);
+        filtered = controllerType switch
+        {
+            MaaControllerTypes.MacOS => ApplyRegexFilters(filtered, controller!.MacOS!),
+            MaaControllerTypes.Gamepad => ApplyRegexFilters(filtered, controller!.Gamepad!),
+            _ => ApplyRegexFilters(filtered, controller!.Win32!)
+        };
 
         var matchedIdx = MatchPreviousWindow(filtered);
         return (matchedIdx >= 0 ? matchedIdx : (filtered.Count > 0 ? 0 : 0), filtered.ToList());
@@ -1856,17 +1874,26 @@ public partial class TaskQueueViewModel : ViewModelBase
 
 
     private List<DesktopWindowInfo> ApplyRegexFilters(List<DesktopWindowInfo> windows, MaaInterface.MaaResourceControllerWin32 win32)
+        => ApplyRegexFilters(windows, win32.ClassRegex, win32.WindowRegex);
+
+    private List<DesktopWindowInfo> ApplyRegexFilters(List<DesktopWindowInfo> windows, MaaInterface.MaaResourceControllerMacOS macOS)
+        => ApplyRegexFilters(windows, macOS.ClassRegex, macOS.WindowRegex);
+
+    private List<DesktopWindowInfo> ApplyRegexFilters(List<DesktopWindowInfo> windows, MaaInterface.MaaResourceControllerGamepad gamepad)
+        => ApplyRegexFilters(windows, gamepad.ClassRegex, gamepad.WindowRegex);
+
+    private List<DesktopWindowInfo> ApplyRegexFilters(List<DesktopWindowInfo> windows, string? classRegex, string? windowRegex)
     {
         var filtered = windows;
-        if (!string.IsNullOrWhiteSpace(win32.WindowRegex))
+        if (!string.IsNullOrWhiteSpace(windowRegex))
         {
-            var regex = new Regex(win32.WindowRegex);
+            var regex = new Regex(windowRegex);
             filtered = filtered.Where(w => regex.IsMatch(w.Name)).ToList();
         }
 
-        if (!string.IsNullOrWhiteSpace(win32.ClassRegex))
+        if (!string.IsNullOrWhiteSpace(classRegex))
         {
-            var regex = new Regex(win32.ClassRegex);
+            var regex = new Regex(classRegex);
             filtered = filtered.Where(w => regex.IsMatch(w.ClassName)).ToList();
         }
         return filtered;
@@ -1943,6 +1970,14 @@ public partial class TaskQueueViewModel : ViewModelBase
         }
         else
         {
+            if (controller.ControllerType == MaaControllerTypes.MacOS)
+            {
+                var macOSInput = ParseMacOSInputMethod(controller.MacOS?.Input);
+                if (macOSInput != null)
+                    Processor.Config.MacOSWindow.Input = macOSInput.Value;
+                return;
+            }
+
             var mouse = controller.Win32?.Mouse;
             if (mouse != null)
             {
@@ -2031,6 +2066,40 @@ public partial class TaskQueueViewModel : ViewModelBase
         };
     }
 
+    private static MacOSInputMethod? ParseMacOSInputMethod(object? value)
+    {
+        if (value == null) return null;
+
+        if (value is string strValue)
+        {
+            if (Enum.TryParse<MacOSInputMethod>(strValue, ignoreCase: true, out var result))
+                return result;
+            return null;
+        }
+
+        var longValue = Convert.ToUInt64(value);
+        return longValue switch
+        {
+            1 => MacOSInputMethod.GlobalEvent,
+            2 => MacOSInputMethod.PostToPid,
+            _ => null
+        };
+    }
+
+    private static MacOSScreencapMethod? ParseMacOSScreencapMethod(object? value)
+    {
+        if (value == null) return null;
+
+        if (value is string strValue)
+        {
+            if (Enum.TryParse<MacOSScreencapMethod>(strValue, ignoreCase: true, out var result))
+                return result;
+            return null;
+        }
+
+        return Convert.ToUInt64(value) == 1 ? MacOSScreencapMethod.ScreenCaptureKit : null;
+    }
+
     private void HandleScreenCapSettings(MaaInterface.MaaResourceController controller, bool isAdb)
     {
         if (isAdb)
@@ -2051,6 +2120,14 @@ public partial class TaskQueueViewModel : ViewModelBase
         }
         else
         {
+            if (controller.ControllerType == MaaControllerTypes.MacOS)
+            {
+                var macOSScreencap = ParseMacOSScreencapMethod(controller.MacOS?.ScreenCap);
+                if (macOSScreencap != null)
+                    Processor.Config.MacOSWindow.ScreenCap = macOSScreencap.Value;
+                return;
+            }
+
             var screenCap = controller.Win32?.ScreenCap;
             if (screenCap == null) return;
             var parsed = ParseWin32ScreencapMethod(screenCap);
@@ -2084,6 +2161,7 @@ public partial class TaskQueueViewModel : ViewModelBase
         {
             MaaControllerTypes.Adb => LangKeys.Emulator,
             MaaControllerTypes.Win32 => LangKeys.Window,
+            MaaControllerTypes.MacOS => LangKeys.Window,
             MaaControllerTypes.PlayCover => LangKeys.TabPlayCover,
             _ => LangKeys.Window
         };

--- a/MFAAvalonia/Views/Windows/RootView.axaml.cs
+++ b/MFAAvalonia/Views/Windows/RootView.axaml.cs
@@ -276,6 +276,7 @@ public partial class RootView : SukiWindow
                             {
                                 MaaControllerTypes.Adb => "Emulator",
                                 MaaControllerTypes.Win32 => "Window",
+                                MaaControllerTypes.MacOS => "Window",
                                 MaaControllerTypes.PlayCover => "TabPlayCover",
                                 _ => "Window"
                             };


### PR DESCRIPTION
## Summary
- add `macos` controller parsing and a `MacOS` controller tab/label
- add a local `MaaMacOSController` wrapper for `MaaMacOSControllerCreate` while the C# binding lacks a high-level wrapper
- wire macOS native window detection, regex filtering, and controller construction into the task queue flow
- keep Gamepad window regex filtering intact while generalizing desktop-window detection

Closes #200

## Adversarial review notes
- fixed a review-found regression where Gamepad window regex filtering could be skipped after generalizing the window detection path
- added an explicit UInt32 range check before passing macOS window ids to MaaFramework to avoid silent handle truncation
- confirmed the current C# binding package does not expose a high-level macOS wrapper, so the local P/Invoke wrapper is intentionally scoped

## Validation
- `dotnet build MFAAvalonia.sln --no-restore --verbosity minimal` passed
- `git diff --check` passed

## Not verified
- native macOS controller runtime behavior still needs validation on macOS with ScreenCapture/Accessibility permissions

## Summary by Sourcery

在配置、检测和运行时控制器初始化中新增原生 macOS 控制器支持，同时泛化桌面窗口处理逻辑，并保持现有 Gamepad 行为不变。

新特性：
- 引入 MacOS 控制器类型和资源模型，包括针对原生 macOS 窗口的输入与屏幕捕获配置。
- 在 UI 中暴露 MacOS 控制器选项，并将其集成到控制器选择和自动检测流程中。
- 添加基于 MaaFramework 的 `MaaMacOSController` 包装器，用于从桌面窗口信息创建并关联 macOS 控制器。

缺陷修复：
- 在泛化桌面窗口检测与过滤逻辑后，确保 Gamepad 桌面窗口的正则表达式过滤仍然有效。
- 在创建 MaaFramework 控制器之前，校验 macOS 窗口标识是否适配 UInt32，以避免句柄截断问题。

增强与改进：
- 将桌面窗口检测和基于正则表达式的过滤泛化为共享逻辑，使其可同时适用于 Win32、Gamepad 和 MacOS 控制器。
- 扩展控制器输入和屏幕捕获设置处理逻辑，从资源配置中解析 macOS 特定方法，并将其应用到运行时配置中。
- 更新控制器类型到资源键和本地化映射，以包含新的 MacOS 控制器类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add native macOS controller support across configuration, detection, and runtime controller initialization, while generalizing desktop window handling and maintaining existing Gamepad behavior.

New Features:
- Introduce a MacOS controller type and resource model, including input and screen capture configuration for native macOS windows.
- Expose a MacOS controller option in the UI and integrate it into controller selection and auto-detection flows.
- Add a MaaMacOSController wrapper over MaaFramework to create and link macOS controllers from desktop window information.

Bug Fixes:
- Ensure Gamepad desktop window regex filtering remains active after generalizing desktop window detection and filtering logic.
- Validate macOS window identifiers fit within UInt32 before creating MaaFramework controllers to avoid handle truncation issues.

Enhancements:
- Generalize desktop window detection and regex-based filtering to work with Win32, Gamepad, and MacOS controllers through shared logic.
- Extend controller input and screen capture settings handling to parse macOS-specific methods from resource configuration and apply them to runtime config.
- Update controller type-to-resource key and localization mappings to include the new MacOS controller type.

</details>

新功能：
- 引入 macOS 控制器类型以及针对原生 macOS 窗口的对应资源配置。
- 在 UI 中暴露 MacOS 控制器选项卡/标签，并在控制器选择与检测流程中加入对 macOS 的支持。
- 添加 `MaaMacOSController` 封装器，通过 MaaFramework 绑定来创建 macOS 控制器。

错误修复：
- 在泛化桌面窗口检测逻辑后，确保 Gamepad 窗口的正则表达式过滤仍然生效。

增强改进：
- 将桌面窗口检测和基于正则的过滤逻辑泛化，通过共享逻辑同时支持 Win32、Gamepad 和 macOS 控制器。
- 扩展输入与屏幕捕获配置解析，以支持 macOS 特定方法，并将其映射到处理器配置中。
- 更新本地化以及“控制器类型 -> 资源键”的映射，以包含新的 macOS 控制器类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在配置、检测和运行时控制器初始化中新增原生 macOS 控制器支持，同时泛化桌面窗口处理逻辑，并保持现有 Gamepad 行为不变。

新特性：
- 引入 MacOS 控制器类型和资源模型，包括针对原生 macOS 窗口的输入与屏幕捕获配置。
- 在 UI 中暴露 MacOS 控制器选项，并将其集成到控制器选择和自动检测流程中。
- 添加基于 MaaFramework 的 `MaaMacOSController` 包装器，用于从桌面窗口信息创建并关联 macOS 控制器。

缺陷修复：
- 在泛化桌面窗口检测与过滤逻辑后，确保 Gamepad 桌面窗口的正则表达式过滤仍然有效。
- 在创建 MaaFramework 控制器之前，校验 macOS 窗口标识是否适配 UInt32，以避免句柄截断问题。

增强与改进：
- 将桌面窗口检测和基于正则表达式的过滤泛化为共享逻辑，使其可同时适用于 Win32、Gamepad 和 MacOS 控制器。
- 扩展控制器输入和屏幕捕获设置处理逻辑，从资源配置中解析 macOS 特定方法，并将其应用到运行时配置中。
- 更新控制器类型到资源键和本地化映射，以包含新的 MacOS 控制器类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add native macOS controller support across configuration, detection, and runtime controller initialization, while generalizing desktop window handling and maintaining existing Gamepad behavior.

New Features:
- Introduce a MacOS controller type and resource model, including input and screen capture configuration for native macOS windows.
- Expose a MacOS controller option in the UI and integrate it into controller selection and auto-detection flows.
- Add a MaaMacOSController wrapper over MaaFramework to create and link macOS controllers from desktop window information.

Bug Fixes:
- Ensure Gamepad desktop window regex filtering remains active after generalizing desktop window detection and filtering logic.
- Validate macOS window identifiers fit within UInt32 before creating MaaFramework controllers to avoid handle truncation issues.

Enhancements:
- Generalize desktop window detection and regex-based filtering to work with Win32, Gamepad, and MacOS controllers through shared logic.
- Extend controller input and screen capture settings handling to parse macOS-specific methods from resource configuration and apply them to runtime config.
- Update controller type-to-resource key and localization mappings to include the new MacOS controller type.

</details>

</details>