### PR TITLE
fix: harden resource update application

### DIFF
--- a/MFAAvalonia/Extensions/MaaFW/AgentHelper.cs
+++ b/MFAAvalonia/Extensions/MaaFW/AgentHelper.cs
@@ -521,11 +521,12 @@ public static class AgentHelper
     /// <summary>
     /// 终止所有 Agent 进程并释放资源
     /// </summary>
-    public static void KillAllAgents(List<AgentContext> contexts, MaaTasker? taskerToDispose = null)
+    public static bool KillAllAgents(List<AgentContext> contexts, MaaTasker? taskerToDispose = null)
     {
+        var allProcessesExited = true;
         foreach (var ctx in contexts)
         {
-            KillSingleAgent(ctx, taskerToDispose);
+            allProcessesExited &= KillSingleAgent(ctx, taskerToDispose);
         }
         contexts.Clear();
 
@@ -534,15 +535,18 @@ public static class AgentHelper
         {
             DisposeMaaTasker(taskerToDispose);
         }
+
+        return allProcessesExited;
     }
 
     /// <summary>
     /// 终止单个 Agent（不处理 MaaTasker）
     /// </summary>
-    public static void KillSingleAgent(AgentContext ctx, MaaTasker? taskerToDispose = null)
+    public static bool KillSingleAgent(AgentContext ctx, MaaTasker? taskerToDispose = null)
     {
         var agentClient = ctx.Client;
         var agentProcess = ctx.Process;
+        var processExited = true;
 
         StopReadStreams(ctx);
 
@@ -590,6 +594,7 @@ public static class AgentHelper
                 catch (Exception ex)
                 {
                     LoggerHelper.Warning($"检查 Agent 进程是否退出失败：{ex.Message}");
+                    hasExited = false;
                 }
 
                 if (!hasExited)
@@ -598,12 +603,16 @@ public static class AgentHelper
                     {
                         LoggerHelper.Info($"正在结束 Agent 进程：{agentProcess.ProcessName}");
                         agentProcess.Kill(true);
-                        agentProcess.WaitForExit(5000);
-                        LoggerHelper.Info("Agent 进程已成功结束。");
+                        processExited = agentProcess.WaitForExit(5000);
+                        if (processExited)
+                            LoggerHelper.Info("Agent 进程已成功结束。");
+                        else
+                            LoggerHelper.Error("结束 Agent 进程超时：等待 5 秒后进程仍未退出。");
                     }
                     catch (Exception ex)
                     {
                         LoggerHelper.Warning($"结束 Agent 进程失败：{ex.Message}");
+                        processExited = false;
                     }
                 }
                 else
@@ -614,15 +623,34 @@ public static class AgentHelper
             catch (Exception e)
             {
                 LoggerHelper.Error($"处理 Agent 进程时发生错误：{e.Message}");
+                processExited = false;
             }
             finally
             {
+                DisposeJob(ctx);
+                if (!processExited)
+                {
+                    try
+                    {
+                        // Closing the Windows job object may terminate the process tree. Verify
+                        // once more before reporting the update environment as safe.
+                        processExited = agentProcess.WaitForExit(1000);
+                    }
+                    catch (Exception ex)
+                    {
+                        LoggerHelper.Warning($"再次确认 Agent 进程退出状态失败：{ex.Message}");
+                    }
+                }
                 try { agentProcess.Dispose(); }
                 catch (Exception e) { LoggerHelper.Warning($"释放 Agent 进程对象失败：{e.Message}"); }
             }
         }
+        else
+        {
+            DisposeJob(ctx);
+        }
 
-        DisposeJob(ctx);
+        return processExited;
     }
 
     /// <summary>

--- a/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
@@ -662,48 +662,48 @@ public class MaaProcessor
     private CancellationTokenSource? _detachedScreenshotCleanupCancellationTokenSource;
     private Task? _detachedScreenshotCleanupTask;
     public MaaTasker? ScreenshotTasker => _screenshotTasker;
-    public void SetTasker(MaaTasker? maaTasker = null)
+    public void SetTasker(MaaTasker? maaTasker = null, bool requireAllStopped = false)
     {
         ResetActionFailedCount();
-        if (maaTasker == null && MaaTasker != null)
+        if (maaTasker == null)
         {
             var oldTasker = MaaTasker;
             MaaTasker = null; // 先设置为 null，防止重复释放
+            var taskerStopped = true;
 
-            try
+            if (oldTasker != null)
             {
-                // 使用超时机制避免无限等待，最多等待 5 秒
-                var stopTask = Task.Run(() =>
+                try
                 {
-                    try
+                    // 使用超时机制避免无限等待，最多等待 5 秒
+                    var stopTask = Task.Run(() => oldTasker.Stop().Wait());
+                    if (!stopTask.Wait(TimeSpan.FromSeconds(5)))
                     {
-                        oldTasker.Stop().Wait();
+                        taskerStopped = false;
+                        LoggerHelper.Warning("停止 MaaTasker 超时：已等待 5 秒。");
                     }
-                    catch (Exception ex)
+                    else if (stopTask.IsFaulted)
                     {
-            LoggerHelper.Warning($"停止 MaaTasker 内部任务失败：{ex.Message}");
+                        taskerStopped = false;
+                        LoggerHelper.Warning($"停止 MaaTasker 内部任务失败：{stopTask.Exception?.GetBaseException().Message}");
                     }
-                });
-
-                if (!stopTask.Wait(TimeSpan.FromSeconds(5)))
-                {
-                    LoggerHelper.Warning("停止 MaaTasker 超时：已等待 5 秒。");
                 }
-            }
-            catch (Exception e)
-            {
-                LoggerHelper.Warning($"停止 MaaTasker 失败：{e.Message}");
+                catch (Exception e)
+                {
+                    taskerStopped = false;
+                    LoggerHelper.Warning($"停止 MaaTasker 失败：{e.Message}");
+                }
             }
 
             _agentStarted = false;
-            AgentHelper.KillAllAgents(_agentContexts, oldTasker);
+            // Agent contexts can outlive MaaTasker after an earlier partial cleanup. Always
+            // terminate them, even when MaaTasker is already null.
+            var agentsStopped = AgentHelper.KillAllAgents(_agentContexts, oldTasker);
             ViewModel?.SetConnected(false);
             DetachScreenshotTasker();
-        }
-        else if (maaTasker == null)
-        {
-            // 即使主 Tasker 已经为空，也要确保截图 Tasker 被清理。
-            DetachScreenshotTasker();
+
+            if (requireAllStopped && (!taskerStopped || !agentsStopped))
+                throw new InvalidOperationException("更新前未能停止所有 MaaTasker 或 Agent 进程。");
         }
         else if (maaTasker != null)
         {

--- a/MFAAvalonia/Helper/PendingUpdateDeletionHelper.cs
+++ b/MFAAvalonia/Helper/PendingUpdateDeletionHelper.cs
@@ -57,8 +57,11 @@ public static class PendingUpdateDeletionHelper
                     try
                     {
                         var directoryPath = ResolveSafePath(entry);
+                        // Only remove an empty directory. The update may have written new files to
+                        // the same path after this entry was queued; recursively deleting here
+                        // would remove those new files on the next launch.
                         if (Directory.Exists(directoryPath))
-                            Directory.Delete(directoryPath, recursive: true);
+                            Directory.Delete(directoryPath, recursive: false);
                         LoggerHelper.Info($"已处理待删除更新目录：目录={directoryPath}");
                     }
                     catch (Exception ex)

--- a/MFAAvalonia/Helper/VersionChecker.cs
+++ b/MFAAvalonia/Helper/VersionChecker.cs
@@ -760,6 +760,7 @@ public static class VersionChecker
         }
 
         await StopTaskersAndAgentsForUpdateAsync();
+        using var updateTransaction = new UpdateFileTransaction(tempPath);
         LoggerHelper.Info((isGithub || isFull || currentVersion.Equals("v0.0.0", StringComparison.OrdinalIgnoreCase)) ? "全量更新" : "增量更新");
         if (isGithub || isFull || currentVersion.Equals("v0.0.0", StringComparison.OrdinalIgnoreCase))
         {
@@ -775,11 +776,12 @@ public static class VersionChecker
                     {
                         File.SetAttributes(rfile, FileAttributes.Normal);
                         LoggerHelper.Info($"准备删除旧文件：文件={rfile}");
-                        DeleteFileWithBackup(rfile);
+                        updateTransaction.DeleteFile(rfile);
                     }
                     catch (Exception ex)
                     {
                         LoggerHelper.Error($"删除旧文件失败：文件={rfile}，原因={ex.Message}", ex);
+                        throw;
                     }
                 }
             }
@@ -795,11 +797,12 @@ public static class VersionChecker
                     {
                         File.SetAttributes(rfile, FileAttributes.Normal);
                         LoggerHelper.Info($"准备删除旧文件：文件={rfile}");
-                        DeleteFileWithBackup(rfile);
+                        updateTransaction.DeleteFile(rfile);
                     }
                     catch (Exception ex)
                     {
                         LoggerHelper.Error($"删除旧文件失败：文件={rfile}，原因={ex.Message}", ex);
+                        throw;
                     }
                 }
             }
@@ -822,7 +825,7 @@ public static class VersionChecker
                 try
                 {
                     var changesJson = JsonConvert.DeserializeObject<MirrorChangesJson>(changes);
-                    ApplyIncrementalDeletions(changesJson);
+                    ApplyIncrementalDeletions(changesJson, updateTransaction);
                 }
                 catch (Exception e)
                 {
@@ -838,7 +841,7 @@ public static class VersionChecker
         var di = new DirectoryInfo(originPath);
         if (di.Exists)
         {
-            await CopyUpdatePayload(originPath, progress, true, default, copyDataFiles: true, copyInstallFiles: !containsCoreApplicationFiles);
+            await CopyUpdatePayload(originPath, progress, true, default, copyDataFiles: true, copyInstallFiles: !containsCoreApplicationFiles, updateTransaction: updateTransaction);
         }
 
         var restartExecutablePath = exeName;
@@ -866,12 +869,9 @@ public static class VersionChecker
                 copyDataFiles: false,
                 copyInstallFiles: true,
                 continueOnCopyFailure: false,
-                skipRunningExecutable: true);
+                skipRunningExecutable: true,
+                updateTransaction: updateTransaction);
 
-            if (HasExecutableFileNameChanged(exeName, restartExecutablePath))
-            {
-                TryRenameExecutableToBackup(exeName, allowCurrentProcessExecutable: true);
-            }
         }
 
         // 所有数据和安装文件成功写入后再提交版本元数据。
@@ -885,8 +885,13 @@ public static class VersionChecker
                 @interface["github"] = MaaProcessor.Interface?.Github ?? MaaProcessor.Interface?.Url;
                 @interface["version"] = latestVersion;
             }
-            await File.WriteAllTextAsync(newInterfacePath, @interface.ToString(Formatting.Indented));
+            updateTransaction.WriteAllText(newInterfacePath, @interface.ToString(Formatting.Indented));
         }
+
+        updateTransaction.Commit();
+
+        if (containsCoreApplicationFiles && HasExecutableFileNameChanged(exeName, restartExecutablePath))
+            TryRenameExecutableToBackup(exeName, allowCurrentProcessExecutable: true);
 
         SetProgress(progress, 100);
         SetStatusText(textBlock, downloadSpeedTextBlock, LangKeys.UpdateCompleted.ToLocalization());
@@ -911,7 +916,7 @@ public static class VersionChecker
             {
                 try
                 {
-                    processor.SetTasker();
+                    processor.SetTasker(requireAllStopped: true);
                 }
                 catch (Exception ex)
                 {
@@ -923,10 +928,10 @@ public static class VersionChecker
         LoggerHelper.Info("程序更新前所有 MaaTasker 和 Agent 进程已停止。");
     }
 
-    private static void ApplyIncrementalDeletions(MirrorChangesJson? changes)
+    private static void ApplyIncrementalDeletions(MirrorChangesJson? changes, UpdateFileTransaction updateTransaction)
     {
-        DeleteIncrementalFiles(changes?.Deleted, "Deleted");
-        DeleteIncrementalFiles(changes?.Modified, "Modified");
+        DeleteIncrementalFiles(changes?.Deleted, "Deleted", updateTransaction);
+        DeleteIncrementalFiles(changes?.Modified, "Modified", updateTransaction);
 
         var directories = (changes?.DeletedDirectories ?? [])
             .Select(relativePath =>
@@ -954,7 +959,7 @@ public static class VersionChecker
         }
     }
 
-    private static void DeleteIncrementalFiles(IEnumerable<string>? relativePaths, string changeType)
+    private static void DeleteIncrementalFiles(IEnumerable<string>? relativePaths, string changeType, UpdateFileTransaction updateTransaction)
     {
         foreach (var relativePath in relativePaths ?? [])
         {
@@ -964,7 +969,7 @@ public static class VersionChecker
                 continue;
 
             LoggerHelper.Info($"准备删除增量更新中标记为 {changeType} 的文件：文件={fullPath}");
-            DeleteFileWithBackup(fullPath);
+            updateTransaction.DeleteFile(fullPath);
             if (File.Exists(fullPath))
                 throw new IOException($"无法删除或备份增量更新文件：{fullPath}");
         }
@@ -977,7 +982,10 @@ public static class VersionChecker
         {
             try
             {
-                Directory.Delete(directoryPath, recursive: true);
+                // deleted_dir entries are processed deepest-first after their files are removed.
+                // Refuse to recursively delete unexpected contents so an incomplete manifest
+                // cannot remove user files or files written later in the same update.
+                Directory.Delete(directoryPath, recursive: false);
                 return;
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
@@ -1151,7 +1159,7 @@ public static class VersionChecker
         DispatcherHelper.PostOnMainThread(() => progressBar?.IsVisible = false);
     }
 
-    public async static Task CopyUpdatePayload(
+    private async static Task CopyUpdatePayload(
         string sourceRoot,
         ProgressBar? progressBar = null,
         bool saveAnnouncement = false,
@@ -1160,7 +1168,8 @@ public static class VersionChecker
         bool copyInstallFiles = true,
         string? installTargetRootOverride = null,
         bool continueOnCopyFailure = false,
-        bool skipRunningExecutable = false)
+        bool skipRunningExecutable = false,
+        UpdateFileTransaction? updateTransaction = null)
     {
         if (string.IsNullOrWhiteSpace(sourceRoot) || !Directory.Exists(sourceRoot))
             return;
@@ -1207,10 +1216,13 @@ public static class VersionChecker
                     Path.GetFullPath(currentProcessPath),
                     StringComparison.OrdinalIgnoreCase))
             {
-                var replaced = await TryReplaceRunningExecutableAsync(item.SourceFile, targetFile, cancellationToken);
-                if (!replaced)
+                var replacement = await TryReplaceRunningExecutableAsync(item.SourceFile, targetFile, cancellationToken);
+                if (!replacement.replaced)
                 {
-                    LoggerHelper.Warning($"替换当前正在运行的同名主程序失败，已跳过：文件={targetFile}");
+                    if (!continueOnCopyFailure)
+                        throw new IOException($"替换当前正在运行的同名主程序失败：{targetFile}");
+
+                    LoggerHelper.Warning($"替换当前正在运行的同名主程序失败，已按继续模式跳过：文件={targetFile}");
                     progressCounter.Current++;
                     DispatcherHelper.PostOnMainThread(() =>
                     {
@@ -1222,6 +1234,9 @@ public static class VersionChecker
                     });
                     continue;
                 }
+
+                if (updateTransaction != null && replacement.backupPath != null)
+                    updateTransaction.TrackReplacement(targetFile, replacement.backupPath);
 
                 progressCounter.Current++;
                 DispatcherHelper.PostOnMainThread(() =>
@@ -1255,19 +1270,26 @@ public static class VersionChecker
                     await Task.Run(() =>
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        var tempTarget = targetFile + ".pending_update";
-                        try
+                        if (updateTransaction != null)
                         {
-                            File.Copy(item.SourceFile, tempTarget, overwrite: true);
+                            updateTransaction.ReplaceFile(item.SourceFile, targetFile, cancellationToken);
                         }
-                        catch
+                        else
                         {
-                            if (File.Exists(tempTarget)) File.Delete(tempTarget);
-                            throw;
+                            var tempTarget = targetFile + ".pending_update";
+                            try
+                            {
+                                File.Copy(item.SourceFile, tempTarget, overwrite: true);
+                            }
+                            catch
+                            {
+                                if (File.Exists(tempTarget)) File.Delete(tempTarget);
+                                throw;
+                            }
+                            if (File.Exists(targetFile))
+                                DeleteFileWithBackup(targetFile);
+                            File.Move(tempTarget, targetFile, overwrite: true);
                         }
-                        if (File.Exists(targetFile))
-                            DeleteFileWithBackup(targetFile);
-                        File.Move(tempTarget, targetFile, overwrite: true);
                     }, cancellationToken);
 
                     File.SetAttributes(targetFile, FileAttributes.Normal);
@@ -1470,6 +1492,148 @@ public static class VersionChecker
     {
         public int Current { get; set; } = 0;
         public int Total { get; set; } = 0;
+    }
+
+    private sealed class UpdateFileTransaction : IDisposable
+    {
+        private sealed record FileChange(string TargetPath, string? BackupPath);
+
+        private readonly string _backupRoot;
+        private readonly List<FileChange> _changes = [];
+        private int _nextBackupId;
+        private bool _committed;
+
+        public UpdateFileTransaction(string tempRoot)
+        {
+            _backupRoot = Path.Combine(tempRoot, $"update_rollback_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_backupRoot);
+        }
+
+        public void DeleteFile(string targetPath)
+        {
+            if (!File.Exists(targetPath))
+                return;
+
+            var backupPath = NextBackupPath();
+            File.SetAttributes(targetPath, FileAttributes.Normal);
+            File.Move(targetPath, backupPath);
+            _changes.Add(new FileChange(targetPath, backupPath));
+        }
+
+        public void ReplaceFile(string sourcePath, string targetPath, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var targetDirectory = Path.GetDirectoryName(targetPath);
+            if (!string.IsNullOrWhiteSpace(targetDirectory))
+                Directory.CreateDirectory(targetDirectory);
+
+            var pendingPath = targetPath + ".pending_update";
+            try
+            {
+                File.Copy(sourcePath, pendingPath, overwrite: true);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                string? backupPath = null;
+                if (File.Exists(targetPath))
+                {
+                    backupPath = NextBackupPath();
+                    File.SetAttributes(targetPath, FileAttributes.Normal);
+                    File.Move(targetPath, backupPath);
+                }
+
+                // Record the change before publishing the new file so rollback also covers a
+                // failure between moving the old target and moving the pending file into place.
+                _changes.Add(new FileChange(targetPath, backupPath));
+                File.Move(pendingPath, targetPath, overwrite: true);
+            }
+            catch
+            {
+                if (File.Exists(pendingPath))
+                    File.Delete(pendingPath);
+                throw;
+            }
+        }
+
+        public void WriteAllText(string targetPath, string content)
+        {
+            var stagedPath = Path.Combine(_backupRoot, $"staged_{Guid.NewGuid():N}.tmp");
+            File.WriteAllText(stagedPath, content);
+            ReplaceFile(stagedPath, targetPath, CancellationToken.None);
+        }
+
+        public void TrackReplacement(string targetPath, string backupPath)
+        {
+            _changes.Add(new FileChange(targetPath, backupPath));
+        }
+
+        public void Commit()
+        {
+            _committed = true;
+            TryDeleteBackupRoot();
+        }
+
+        public void Dispose()
+        {
+            if (!_committed)
+            {
+                if (Rollback())
+                    TryDeleteBackupRoot();
+                return;
+            }
+
+            TryDeleteBackupRoot();
+        }
+
+        private string NextBackupPath() =>
+            Path.Combine(_backupRoot, $"{_nextBackupId++:D8}.bak");
+
+        private bool Rollback()
+        {
+            var succeeded = true;
+            LoggerHelper.Warning($"更新未完成，开始回滚已修改文件：数量={_changes.Count}");
+            for (var index = _changes.Count - 1; index >= 0; index--)
+            {
+                var change = _changes[index];
+                try
+                {
+                    if (File.Exists(change.TargetPath))
+                    {
+                        File.SetAttributes(change.TargetPath, FileAttributes.Normal);
+                        File.Delete(change.TargetPath);
+                    }
+
+                    if (change.BackupPath != null && File.Exists(change.BackupPath))
+                    {
+                        var targetDirectory = Path.GetDirectoryName(change.TargetPath);
+                        if (!string.IsNullOrWhiteSpace(targetDirectory))
+                            Directory.CreateDirectory(targetDirectory);
+                        File.Move(change.BackupPath, change.TargetPath, overwrite: true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    succeeded = false;
+                    LoggerHelper.Error($"回滚更新文件失败：目标={change.TargetPath}，备份={change.BackupPath}，原因={ex.Message}", ex);
+                }
+            }
+
+            if (!succeeded)
+                LoggerHelper.Error($"部分更新文件回滚失败，已保留回滚目录供手动恢复：目录={_backupRoot}");
+            return succeeded;
+        }
+
+        private void TryDeleteBackupRoot()
+        {
+            try
+            {
+                if (Directory.Exists(_backupRoot))
+                    Directory.Delete(_backupRoot, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.Warning($"清理更新回滚目录失败：目录={_backupRoot}，原因={ex.Message}");
+            }
+        }
     }
 
     static void DeleteFileWithBackup(string filePath)
@@ -3106,9 +3270,29 @@ public static class VersionChecker
         return backupFilePath;
     }
 
-    private static async Task<bool> TryReplaceRunningExecutableAsync(string sourceFile, string targetFile, CancellationToken cancellationToken)
+    private static async Task<(bool replaced, string? backupPath)> TryReplaceRunningExecutableAsync(
+        string sourceFile,
+        string targetFile,
+        CancellationToken cancellationToken)
     {
         var maxRetries = 5;
+        string? backupPath = null;
+        void RestoreBackupAfterFailure()
+        {
+            if (backupPath == null || !File.Exists(backupPath) || File.Exists(targetFile))
+                return;
+
+            try
+            {
+                File.Move(backupPath, targetFile);
+                backupPath = null;
+            }
+            catch (Exception ex)
+            {
+                LoggerHelper.Error($"恢复替换失败的主程序失败：目标={targetFile}，备份={backupPath}，原因={ex.Message}", ex);
+            }
+        }
+
         for (var i = 0; i < maxRetries; i++)
         {
             try
@@ -3117,31 +3301,57 @@ public static class VersionChecker
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var backupPath = GetBackupMfaPath(targetFile);
-                    File.SetAttributes(targetFile, FileAttributes.Normal);
-                    File.Move(targetFile, backupPath);
-                    LoggerHelper.Info($"当前运行中的旧主程序已改名为 backupMFA：源文件={targetFile}，备份文件={backupPath}");
+                    if (backupPath == null)
+                    {
+                        backupPath = GetBackupMfaPath(targetFile);
+                        File.SetAttributes(targetFile, FileAttributes.Normal);
+                        File.Move(targetFile, backupPath);
+                        LoggerHelper.Info($"当前运行中的旧主程序已改名为 backupMFA：源文件={targetFile}，备份文件={backupPath}");
+                    }
 
                     File.Copy(sourceFile, targetFile, overwrite: false);
                     File.SetAttributes(targetFile, FileAttributes.Normal);
                     LoggerHelper.Info($"新的同名主程序已复制完成：源文件={sourceFile}，目标文件={targetFile}");
                 }, cancellationToken);
 
-                return true;
+                return (true, backupPath);
             }
             catch (IOException ex) when (!cancellationToken.IsCancellationRequested)
             {
                 LoggerHelper.Warning($"替换当前运行中的同名主程序失败，准备重试：第 {i + 1}/{maxRetries} 次，源文件={sourceFile}，目标文件={targetFile}，原因={ex.Message}");
-                await Task.Delay(1000, cancellationToken);
+                try
+                {
+                    await Task.Delay(1000, cancellationToken);
+                }
+                catch
+                {
+                    RestoreBackupAfterFailure();
+                    throw;
+                }
             }
             catch (UnauthorizedAccessException ex)
             {
                 LoggerHelper.Warning($"替换当前运行中的同名主程序被拒绝，准备重试：第 {i + 1}/{maxRetries} 次，源文件={sourceFile}，目标文件={targetFile}，原因={ex.Message}");
-                await Task.Delay(1000, cancellationToken);
+                try
+                {
+                    await Task.Delay(1000, cancellationToken);
+                }
+                catch
+                {
+                    RestoreBackupAfterFailure();
+                    throw;
+                }
+            }
+            catch
+            {
+                RestoreBackupAfterFailure();
+                throw;
             }
         }
 
-        return false;
+        RestoreBackupAfterFailure();
+
+        return (false, backupPath);
     }
 
     private static bool HasExecutableFileNameChanged(string currentExecutablePath, string nextExecutablePath)


### PR DESCRIPTION
## Summary by Sourcery

通过引入事务性的更新处理机制以及更严格的进程终止检查，使资源更新更加安全。

Bug Fixes:
- 通过事务性更新机制，确保在更新过程中发生失败时，文件删除和替换操作能够回滚。
- 通过避免递归删除目录，防止不完整的清单或未完成的删除操作误删用户意料之外的文件。
- 当无法在应用核心更新前彻底停止 MaaTasker 或 Agent 进程时，使更新失败，从而确保更安全的更新前置条件。
- 修复对正在运行的可执行文件进行替换时的逻辑，在失败时能够正确恢复备份，并跟踪替换操作以支持回滚。

Enhancements:
- 优化更新负载的复制逻辑，在替换正在运行的可执行文件时，可选择强制失败而不是静默跳过。
- 将更新文件操作封装到一个私有的事务性辅助类中，以集中管理回滚和清理逻辑。
- 收紧 MaaTasker 和 Agent 的关闭逻辑，更准确地报告和记录超时或失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce transactional update handling and stricter process termination checks for safer resource updates.

Bug Fixes:
- Ensure file deletions and replacements during updates are rollbackable on failure using a transactional update mechanism.
- Prevent incomplete manifests or pending deletions from removing unexpected user files by avoiding recursive directory deletions.
- Fail updates when MaaTasker or Agent processes cannot be fully stopped before applying core updates, ensuring safer update preconditions.
- Fix replacement of the running executable to properly restore backups on failure and to track replacements for rollback.

Enhancements:
- Refine update payload copying to optionally enforce failures instead of silently skipping when replacing the running executable.
- Encapsulate update file operations into a private transactional helper class to centralize rollback and cleanup logic.
- Tighten MaaTasker and Agent shutdown logic to report and log timeout or failure cases more accurately.

</details>