### PR TITLE
docs: fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,6 @@ MFAAvalonia 使用了 [MaaFramework](https://github.com/MaaXYZ/MaaFramework)、[
 
 **如果这个项目对你有帮助，请给我们一个 ⭐ Star！**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=MaaXYZ/MFAAvalonia&type=Date)](https://star-history.com/#MaaXYZ/MFAAvalonia&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=MaaXYZ/MFAAvalonia&type=Date)](https://star-history.dera.page/#MaaXYZ/MFAAvalonia&Date)
 
 </div>

--- a/README_en.md
+++ b/README_en.md
@@ -200,6 +200,6 @@ Thanks to everyone who has contributed to MFAAvalonia.
 
 **If this project helps you, please give us a ⭐ Star!**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=MaaXYZ/MFAAvalonia&type=Date)](https://star-history.com/#MaaXYZ/MFAAvalonia&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=MaaXYZ/MFAAvalonia&type=Date)](https://star-history.dera.page/#MaaXYZ/MFAAvalonia&Date)
 
 </div>


### PR DESCRIPTION
The Star History chart on the README is currently broken because GitHub stargazer API restrictions prevent it from loading, so the project no longer shows its growth. This PR points the chart to the star-history.dera.page service, which serves the same charts from a data source that does not require an API token. Applies to both README.md and README_en.md.

## Summary by Sourcery

文档：
- 更新中文和英文版 README 中的星标历史图链接，指向 star-history.dera.page 服务，以便在无需访问 GitHub API 的情况下可靠地渲染这些图表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update star history chart links in both Chinese and English READMEs to point to the star-history.dera.page service so the charts render reliably without GitHub API access.

</details>