### PR TITLE
fix(telemetry): harden failure evidence boundaries

### DIFF
--- a/MFAAvalonia/Helper/TaskDiagnostics.cs
+++ b/MFAAvalonia/Helper/TaskDiagnostics.cs
@@ -4,24 +4,29 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace MFAAvalonia.Helper;
+
+internal sealed record EvidenceFileStamp(long Length, DateTime? LastWriteUtc);
 
 internal sealed class TaskEvidenceSnapshot
 {
     internal required DateTimeOffset StartedAt { get; init; }
     internal required Dictionary<string, long> LogLengths { get; init; }
-    internal required Dictionary<string, (long Length, DateTime LastWriteUtc)> ExistingErrorImages { get; init; }
+    internal required Dictionary<string, EvidenceFileStamp> ExistingErrorImages { get; init; }
+    internal required IReadOnlyList<string> Warnings { get; init; }
     internal required bool Isolated { get; init; }
 }
 
 internal enum TaskEvidenceBuildStatus
 {
     Success,
-    NotIsolated,
+    ConcurrentInstance,
     NoEvidence,
     RawTooLarge,
-    CompressedTooLarge
+    BundleTooLarge,
+    BuildFailed
 }
 
 internal sealed record DiagnosticLogContent(
@@ -34,118 +39,322 @@ internal sealed record DiagnosticLogBuildResult(
     TaskEvidenceBuildStatus Status,
     IReadOnlyList<DiagnosticLogContent> Logs,
     long RawBytes,
-    bool Truncated);
+    bool Truncated,
+    IReadOnlyList<string> Warnings);
 
 internal sealed record ImageEvidenceBuildResult(
     TaskEvidenceBuildStatus Status,
     byte[]? Data,
     int ImageCount,
-    long RawBytes);
+    long RawBytes,
+    long BundleBytes,
+    IReadOnlyList<string> Warnings);
 
 internal sealed record TaskEvidenceBuildResult(
     DiagnosticLogBuildResult Logs,
     ImageEvidenceBuildResult Images);
 
+internal sealed class EvidenceFileSlice : IDisposable
+{
+    internal required FileStream Source { get; init; }
+    internal required string Name { get; init; }
+    internal required long Start { get; set; }
+    internal required long End { get; init; }
+    internal required DateTime LastWriteUtc { get; init; }
+    internal required EvidenceFileStamp Stamp { get; init; }
+
+    public void Dispose() => Source.Dispose();
+}
+
+internal sealed class TaskEvidenceSelection : IDisposable
+{
+    internal required bool Isolated { get; init; }
+    internal required DateTimeOffset StartedAt { get; init; }
+    internal required Dictionary<string, EvidenceFileStamp> ExistingErrorImages { get; init; }
+    internal required List<EvidenceFileSlice> Logs { get; init; }
+    internal required List<EvidenceFileSlice> Images { get; init; }
+    internal required List<string> Warnings { get; init; }
+
+    public void Dispose()
+    {
+        foreach (var item in Logs) item.Dispose();
+        foreach (var item in Images) item.Dispose();
+        Logs.Clear();
+        Images.Clear();
+    }
+}
+
+internal sealed class TaskImageRefresh : IDisposable
+{
+    internal required List<EvidenceFileSlice> Images { get; init; }
+    internal required List<string> Warnings { get; init; }
+
+    public void Dispose()
+    {
+        foreach (var item in Images) item.Dispose();
+        Images.Clear();
+    }
+}
+
 internal static class TaskDiagnostics
 {
-    private const long MaxImageRawBytes = 64 * 1024 * 1024;
-    private const int MaxImageCompressedBytes = 10 * 1024 * 1024;
+    private const long MaxImageRawBytes = 5 * 1024 * 1024;
+    private const int MaxImageBundleBytes = 5 * 1024 * 1024;
+    private const int MaxImageFiles = 128;
     private const int MaxLogRawBytes = 1024 * 1024;
     private const int MaxLogFileBytes = 512 * 1024;
+    private const int MaxLogFiles = 128;
     private const int LogPreludeBytes = 64 * 1024;
     private const int ExceptionLogTailBytes = 256 * 1024;
     private const int MaxExceptionLogFiles = 5;
+    private const int MaxDiscoveryEntries = 8 * 1024;
+    private const int MaxDiscoveryDepth = 16;
+    private const int MaxWarnings = 32;
+    private static readonly TimeSpan MtimeTolerance = TimeSpan.FromSeconds(2);
 
-    internal static TaskEvidenceSnapshot CaptureStart(bool isolated)
+    internal static TaskEvidenceSnapshot CaptureStart(bool isolated, CancellationToken cancellationToken = default)
     {
+        var startedAt = DateTimeOffset.UtcNow;
         var logs = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
-        var images = new Dictionary<string, (long Length, DateTime LastWriteUtc)>(StringComparer.OrdinalIgnoreCase);
-        foreach (var path in EnumerateEvidenceFiles())
+        var images = new Dictionary<string, EvidenceFileStamp>(StringComparer.OrdinalIgnoreCase);
+        var warnings = new List<string>();
+        if (!isolated)
         {
-            var relative = Relative(path);
-            try
+            return new TaskEvidenceSnapshot
             {
-                if (IsLog(relative)) logs[relative] = new FileInfo(path).Length;
-                else if (IsErrorImage(relative))
-                {
-                    var info = new FileInfo(path);
-                    images[relative] = (info.Length, info.LastWriteTimeUtc);
-                }
-            }
-            catch { }
-        }
-        return new TaskEvidenceSnapshot { StartedAt = DateTimeOffset.UtcNow, LogLengths = logs, ExistingErrorImages = images, Isolated = isolated };
-    }
-
-    internal static TaskEvidenceBuildResult Build(TaskEvidenceSnapshot snapshot)
-    {
-        if (!snapshot.Isolated)
-        {
-            return new TaskEvidenceBuildResult(
-                EmptyLogs(TaskEvidenceBuildStatus.NotIsolated),
-                EmptyImages(TaskEvidenceBuildStatus.NotIsolated));
+                StartedAt = startedAt,
+                LogLengths = logs,
+                ExistingErrorImages = images,
+                Warnings = warnings,
+                Isolated = false
+            };
         }
 
-        var logCandidates = new List<LogCandidate>();
-        var imageCandidates = new List<(string Path, string Name, long Length)>();
-        foreach (var path in EnumerateEvidenceFiles())
+        foreach (var path in EnumerateEvidenceFiles(warnings, cancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var relative = Relative(path);
             try
             {
                 var info = new FileInfo(path);
-                if (IsLog(relative) && snapshot.LogLengths.TryGetValue(relative, out var oldLength) && info.Length > oldLength)
+                if (IsLog(relative))
                 {
-                    var start = Math.Max(0, oldLength - LogPreludeBytes);
-                    logCandidates.Add(new LogCandidate(path, relative, start, info.Length - start, info.LastWriteTimeUtc));
+                    logs[relative] = info.Length;
                 }
-                else if (IsLog(relative)
-                         && !snapshot.LogLengths.ContainsKey(relative)
-                         && info.LastWriteTimeUtc >= snapshot.StartedAt.UtcDateTime.AddSeconds(-2))
+                else if (IsErrorImage(relative))
                 {
-                    logCandidates.Add(new LogCandidate(path, relative, 0, info.Length, info.LastWriteTimeUtc));
-                }
-                else if (IsErrorImage(relative)
-                         && info.LastWriteTimeUtc >= snapshot.StartedAt.UtcDateTime.AddSeconds(-2)
-                         && (!snapshot.ExistingErrorImages.TryGetValue(relative, out var previous)
-                             || previous.Length != info.Length
-                             || previous.LastWriteUtc != info.LastWriteTimeUtc))
-                {
-                    imageCandidates.Add((path, relative, info.Length));
+                    var stamp = new EvidenceFileStamp(info.Length, TryGetLastWriteUtc(info));
+                    if (!stamp.LastWriteUtc.HasValue || stamp.LastWriteUtc.Value < startedAt.UtcDateTime)
+                        images[relative] = stamp;
                 }
             }
-            catch { }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                AddWarning(warnings, $"snapshot_metadata_failed:{Path.GetFileName(path)}:{ex.GetType().Name}");
+            }
         }
 
-        return new TaskEvidenceBuildResult(BuildLogs(logCandidates), BuildImages(imageCandidates));
+        return new TaskEvidenceSnapshot
+        {
+            StartedAt = startedAt,
+            LogLengths = logs,
+            ExistingErrorImages = images,
+            Warnings = warnings,
+            Isolated = true
+        };
     }
 
-    internal static DiagnosticLogBuildResult BuildRecentLogs()
+    internal static TaskEvidenceSelection CaptureEnd(
+        TaskEvidenceSnapshot snapshot,
+        bool isolatedAtEnd,
+        CancellationToken cancellationToken = default)
     {
-        var selected = EnumerateEvidenceFiles()
-            .Where(path => IsLog(Relative(path)))
-            .Select(path =>
+        var warnings = new List<string>(snapshot.Warnings);
+        var selection = new TaskEvidenceSelection
+        {
+            Isolated = snapshot.Isolated && isolatedAtEnd,
+            StartedAt = snapshot.StartedAt,
+            ExistingErrorImages = snapshot.ExistingErrorImages,
+            Logs = [],
+            Images = [],
+            Warnings = warnings
+        };
+        if (!selection.Isolated) return selection;
+
+        try
+        {
+            foreach (var path in EnumerateEvidenceFiles(warnings, cancellationToken))
             {
-                try
+                cancellationToken.ThrowIfCancellationRequested();
+                var relative = Relative(path);
+                if (IsErrorImage(relative))
                 {
-                    var info = new FileInfo(path);
-                    var length = Math.Min(info.Length, ExceptionLogTailBytes);
-                    return new LogCandidate(path, Relative(path), info.Length - length, length, info.LastWriteTimeUtc);
+                    if (selection.Images.Count >= MaxImageFiles)
+                    {
+                        AddWarning(warnings, $"image_file_limit_reached:{MaxImageFiles}");
+                        continue;
+                    }
+                    var image = TryOpenImage(path, relative, snapshot, warnings);
+                    if (image != null) selection.Images.Add(image);
                 }
-                catch { return null; }
-            })
-            .Where(item => item != null)
-            .Cast<LogCandidate>()
-            .OrderBy(item => GetLogPriority(item.Name))
-            .ThenByDescending(item => item.LastWriteUtc)
-            .Take(MaxExceptionLogFiles)
-            .ToList();
-
-        return BuildLogs(selected);
+                else if (IsLog(relative))
+                {
+                    if (selection.Logs.Count >= MaxLogFiles)
+                    {
+                        AddWarning(warnings, $"log_file_limit_reached:{MaxLogFiles}");
+                        continue;
+                    }
+                    var log = TryOpenLog(path, relative, snapshot, warnings);
+                    if (log != null) selection.Logs.Add(log);
+                }
+            }
+            SortSlices(selection.Logs);
+            SortSlices(selection.Images);
+            return selection;
+        }
+        catch
+        {
+            selection.Dispose();
+            throw;
+        }
     }
 
-    private static DiagnosticLogBuildResult BuildLogs(IEnumerable<LogCandidate> candidates)
+    internal static TaskImageRefresh CaptureImageRefresh(
+        TaskEvidenceSelection selection,
+        CancellationToken cancellationToken = default)
     {
+        var refresh = new TaskImageRefresh { Images = [], Warnings = [] };
+        if (!selection.Isolated) return refresh;
+
+        try
+        {
+            foreach (var path in EnumerateEvidenceFiles(refresh.Warnings, cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var relative = Relative(path);
+                if (!IsErrorImage(relative)) continue;
+                if (refresh.Images.Count >= MaxImageFiles)
+                {
+                    AddWarning(refresh.Warnings, $"image_file_limit_reached:{MaxImageFiles}");
+                    break;
+                }
+                var image = TryOpenImage(path, relative, selection.StartedAt,
+                    selection.ExistingErrorImages, refresh.Warnings);
+                if (image != null) refresh.Images.Add(image);
+            }
+            SortSlices(refresh.Images);
+            return refresh;
+        }
+        catch
+        {
+            refresh.Dispose();
+            throw;
+        }
+    }
+
+    internal static void ApplyImageRefresh(TaskEvidenceSelection selection, TaskImageRefresh refresh)
+    {
+        foreach (var image in refresh.Images.ToArray())
+        {
+            var index = selection.Images.FindIndex(existing =>
+                string.Equals(existing.Name, image.Name, StringComparison.OrdinalIgnoreCase));
+            if (index < 0)
+            {
+                selection.Images.Add(image);
+                if (selection.Images.Count > MaxImageFiles)
+                {
+                    var oldest = selection.Images
+                        .OrderBy(item => item.LastWriteUtc)
+                        .ThenBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
+                        .First();
+                    selection.Images.Remove(oldest);
+                    oldest.Dispose();
+                    AddWarning(selection.Warnings, $"image_file_limit_reached:{MaxImageFiles}");
+                }
+            }
+            else if (selection.Images[index].Stamp != image.Stamp)
+            {
+                selection.Images[index].Dispose();
+                selection.Images[index] = image;
+            }
+            else
+            {
+                image.Dispose();
+            }
+        }
+        refresh.Images.Clear();
+        foreach (var warning in refresh.Warnings) AddWarning(selection.Warnings, warning);
+        SortSlices(selection.Images);
+    }
+
+    internal static TaskEvidenceBuildResult Build(
+        TaskEvidenceSelection selection,
+        bool buildImages,
+        CancellationToken cancellationToken = default)
+    {
+        if (!selection.Isolated)
+        {
+            return new TaskEvidenceBuildResult(
+                EmptyLogs(TaskEvidenceBuildStatus.ConcurrentInstance, selection.Warnings),
+                EmptyImages(TaskEvidenceBuildStatus.ConcurrentInstance, selection.Warnings));
+        }
+        var logs = BuildLogs(selection.Logs, selection.Warnings, cancellationToken);
+        if (!buildImages)
+            return new TaskEvidenceBuildResult(
+                logs, EmptyImages(TaskEvidenceBuildStatus.NoEvidence, selection.Warnings));
+
+        try
+        {
+            return new TaskEvidenceBuildResult(
+                logs, BuildImages(selection.Images, selection.Warnings, cancellationToken));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException and not OutOfMemoryException)
+        {
+            var warnings = new List<string>(selection.Warnings);
+            AddWarning(warnings, $"build_images_failed:{ex.GetType().Name}");
+            return new TaskEvidenceBuildResult(
+                logs, EmptyImages(TaskEvidenceBuildStatus.BuildFailed, warnings));
+        }
+    }
+
+    internal static DiagnosticLogBuildResult BuildRecentLogs(CancellationToken cancellationToken = default)
+    {
+        var warnings = new List<string>();
+        var selected = new List<EvidenceFileSlice>();
+        try
+        {
+            foreach (var path in EnumerateEvidenceFiles(warnings, cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var relative = Relative(path);
+                if (!IsLog(relative)) continue;
+                if (selected.Count >= MaxLogFiles)
+                {
+                    AddWarning(warnings, $"log_file_limit_reached:{MaxLogFiles}");
+                    break;
+                }
+                var slice = TryOpenWholeTail(path, relative, ExceptionLogTailBytes, warnings);
+                if (slice != null) selected.Add(slice);
+            }
+            var retained = selected
+                .OrderBy(item => GetLogPriority(item.Name))
+                .ThenByDescending(item => item.LastWriteUtc)
+                .Take(MaxExceptionLogFiles)
+                .ToHashSet();
+            return BuildLogs(retained, warnings, cancellationToken);
+        }
+        finally
+        {
+            foreach (var item in selected) item.Dispose();
+        }
+    }
+
+    private static DiagnosticLogBuildResult BuildLogs(
+        IEnumerable<EvidenceFileSlice> candidates,
+        IReadOnlyList<string> inheritedWarnings,
+        CancellationToken cancellationToken)
+    {
+        var warnings = new List<string>(inheritedWarnings);
         var logs = new List<DiagnosticLogContent>();
         var rawBytes = 0L;
         var truncated = false;
@@ -153,77 +362,196 @@ internal static class TaskDiagnostics
                      .OrderBy(candidate => GetLogPriority(candidate.Name))
                      .ThenByDescending(candidate => candidate.LastWriteUtc))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var remainingBudget = MaxLogRawBytes - rawBytes;
             if (remainingBudget <= 0)
             {
                 truncated = true;
                 break;
             }
-
-            var readLength = Math.Min(item.Length, Math.Min(MaxLogFileBytes, remainingBudget));
-            if (readLength <= 0)
-                continue;
-
-            // Keep the end of each selected range: failure details are normally emitted last.
-            var readStart = item.Start + item.Length - readLength;
+            var selectedLength = item.End - item.Start;
+            var readLength = Math.Min(selectedLength, Math.Min(MaxLogFileBytes, remainingBudget));
+            if (readLength <= 0) continue;
+            var readStart = item.End - readLength;
             try
             {
-                var data = ReadBytes(item.Path, readStart, readLength);
-                if (data.Length == 0)
-                    continue;
-
+                var data = ReadBytes(item, readStart, readLength, cancellationToken);
+                if (data.Length == 0) continue;
                 var content = Encoding.UTF8.GetString(data).Trim('\0');
-                if (string.IsNullOrWhiteSpace(content))
-                    continue;
-
+                if (string.IsNullOrWhiteSpace(content)) continue;
                 logs.Add(new DiagnosticLogContent(item.Name, GetLogKind(item.Name), content, data.Length));
                 rawBytes += data.Length;
-                truncated |= readLength < item.Length;
+                truncated |= readLength < selectedLength;
             }
-            catch { }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                AddWarning(warnings, $"read_log_failed:{item.Name}:{ex.GetType().Name}");
+            }
         }
 
         return logs.Count == 0
-            ? EmptyLogs(TaskEvidenceBuildStatus.NoEvidence)
-            : new DiagnosticLogBuildResult(TaskEvidenceBuildStatus.Success, logs, rawBytes, truncated);
+            ? EmptyLogs(TaskEvidenceBuildStatus.NoEvidence, warnings)
+            : new DiagnosticLogBuildResult(TaskEvidenceBuildStatus.Success, logs, rawBytes, truncated, warnings);
     }
 
-    private static ImageEvidenceBuildResult BuildImages(IReadOnlyCollection<(string Path, string Name, long Length)> selected)
+    private static ImageEvidenceBuildResult BuildImages(
+        IReadOnlyCollection<EvidenceFileSlice> selected,
+        IReadOnlyList<string> inheritedWarnings,
+        CancellationToken cancellationToken)
     {
-        if (selected.Count == 0)
-            return EmptyImages(TaskEvidenceBuildStatus.NoEvidence);
+        var warnings = new List<string>(inheritedWarnings);
+        if (selected.Count == 0) return EmptyImages(TaskEvidenceBuildStatus.NoEvidence, warnings);
 
-        var rawBytes = selected.Sum(item => item.Length);
-        if (rawBytes > MaxImageRawBytes)
-            return new ImageEvidenceBuildResult(TaskEvidenceBuildStatus.RawTooLarge, null, selected.Count, rawBytes);
+        var rawBytes = 0L;
+        foreach (var item in selected)
+        {
+            var length = item.End - item.Start;
+            if (length < 0 || length > MaxImageRawBytes - rawBytes)
+            {
+                var observedRawBytes = length < 0 || length > long.MaxValue - rawBytes
+                    ? long.MaxValue
+                    : rawBytes + length;
+                return new ImageEvidenceBuildResult(
+                    TaskEvidenceBuildStatus.RawTooLarge, null, selected.Count,
+                    observedRawBytes, 0, warnings);
+            }
+            rawBytes += length;
+        }
 
-        using var output = new MemoryStream();
+        using var output = new MemoryStream((int)Math.Min(MaxImageBundleBytes + 1L, rawBytes + 64 * 1024L));
         using (var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true))
         {
-            foreach (var item in selected)
+            foreach (var item in selected.OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase))
             {
-                var entry = archive.CreateEntry(item.Name, CompressionLevel.Fastest);
+                cancellationToken.ThrowIfCancellationRequested();
+                var entry = archive.CreateEntry(item.Name, CompressionLevel.NoCompression);
                 using var target = entry.Open();
-                using var source = new FileStream(item.Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-                source.CopyTo(target);
+                CopySlice(item, target, cancellationToken);
             }
         }
 
-        return output.Length > MaxImageCompressedBytes
-            ? new ImageEvidenceBuildResult(TaskEvidenceBuildStatus.CompressedTooLarge, null, selected.Count, rawBytes)
-            : new ImageEvidenceBuildResult(TaskEvidenceBuildStatus.Success, output.ToArray(), selected.Count, rawBytes);
+        if (output.Length > MaxImageBundleBytes)
+            return new ImageEvidenceBuildResult(
+                TaskEvidenceBuildStatus.BundleTooLarge, null, selected.Count,
+                rawBytes, output.Length, warnings);
+        return new ImageEvidenceBuildResult(
+            TaskEvidenceBuildStatus.Success, output.ToArray(), selected.Count,
+            rawBytes, output.Length, warnings);
     }
 
-    private static byte[] ReadBytes(string path, long start, long length)
+    private static EvidenceFileSlice? TryOpenLog(
+        string path,
+        string relative,
+        TaskEvidenceSnapshot snapshot,
+        List<string> warnings)
     {
-        using var source = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-        source.Position = start;
+        var slice = TryOpenWholeTail(path, relative, long.MaxValue, warnings);
+        if (slice == null) return null;
+        var length = slice.End;
+        var modified = ModifiedSince(slice.LastWriteUtc, snapshot.StartedAt.UtcDateTime);
+        if (snapshot.LogLengths.TryGetValue(relative, out var previousLength))
+        {
+            if (length > previousLength)
+            {
+                slice.Start = Math.Max(0, previousLength - LogPreludeBytes);
+            }
+            else if (length < previousLength && modified && length > 0)
+            {
+                AddWarning(warnings, $"rotated_log_included_whole:{relative}");
+            }
+            else if (length == previousLength && modified && length > 0)
+            {
+                AddWarning(warnings, $"log_changed_during_start_snapshot:{relative}");
+                slice.Start = Math.Max(0, length - LogPreludeBytes);
+            }
+            else
+            {
+                slice.Dispose();
+                return null;
+            }
+        }
+        else if (!modified || length == 0)
+        {
+            slice.Dispose();
+            return null;
+        }
+        else
+        {
+            AddWarning(warnings, $"new_log_included_whole:{relative}");
+        }
+        return slice;
+    }
+
+    private static EvidenceFileSlice? TryOpenImage(
+        string path,
+        string relative,
+        TaskEvidenceSnapshot snapshot,
+        List<string> warnings) =>
+        TryOpenImage(path, relative, snapshot.StartedAt, snapshot.ExistingErrorImages, warnings);
+
+    private static EvidenceFileSlice? TryOpenImage(
+        string path,
+        string relative,
+        DateTimeOffset startedAt,
+        IReadOnlyDictionary<string, EvidenceFileStamp> existingImages,
+        List<string> warnings)
+    {
+        var slice = TryOpenWholeTail(path, relative, long.MaxValue, warnings);
+        if (slice == null) return null;
+        if (!ModifiedSince(slice.LastWriteUtc, startedAt.UtcDateTime)
+            || existingImages.TryGetValue(relative, out var previous) && previous == slice.Stamp)
+        {
+            slice.Dispose();
+            return null;
+        }
+        return slice;
+    }
+
+    private static EvidenceFileSlice? TryOpenWholeTail(
+        string path,
+        string relative,
+        long maxLength,
+        List<string> warnings)
+    {
+        FileStream? source = null;
+        try
+        {
+            source = new FileStream(path, FileMode.Open, FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete, 4096, FileOptions.SequentialScan);
+            var length = source.Length;
+            var lastWriteUtc = File.GetLastWriteTimeUtc(source.SafeFileHandle);
+            return new EvidenceFileSlice
+            {
+                Source = source,
+                Name = relative,
+                Start = Math.Max(0, length - maxLength),
+                End = length,
+                LastWriteUtc = lastWriteUtc,
+                Stamp = new EvidenceFileStamp(length, lastWriteUtc)
+            };
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            source?.Dispose();
+            AddWarning(warnings, $"open_evidence_failed:{relative}:{ex.GetType().Name}");
+            return null;
+        }
+    }
+
+    private static byte[] ReadBytes(
+        EvidenceFileSlice item,
+        long start,
+        long length,
+        CancellationToken cancellationToken)
+    {
+        item.Source.Position = start;
         using var output = new MemoryStream((int)Math.Min(length, int.MaxValue));
         var remaining = length;
         var buffer = new byte[81920];
         while (remaining > 0)
         {
-            var read = source.Read(buffer, 0, (int)Math.Min(buffer.Length, remaining));
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = item.Source.Read(buffer, 0, (int)Math.Min(buffer.Length, remaining));
             if (read <= 0) break;
             output.Write(buffer, 0, read);
             remaining -= read;
@@ -231,23 +559,153 @@ internal static class TaskDiagnostics
         return output.ToArray();
     }
 
-    private static IEnumerable<string> EnumerateEvidenceFiles()
+    private static void CopySlice(
+        EvidenceFileSlice item,
+        Stream target,
+        CancellationToken cancellationToken)
+    {
+        item.Source.Position = item.Start;
+        var remaining = item.End - item.Start;
+        var buffer = new byte[81920];
+        while (remaining > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = item.Source.Read(buffer, 0, (int)Math.Min(buffer.Length, remaining));
+            if (read <= 0)
+                throw new EndOfStreamException($"Evidence file became shorter: {item.Name}");
+            target.Write(buffer, 0, read);
+            remaining -= read;
+        }
+    }
+
+    private static IEnumerable<string> EnumerateEvidenceFiles(
+        List<string> warnings,
+        CancellationToken cancellationToken)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var pending = new Stack<(string Root, string Directory, int Depth)>();
+        var dataRoot = Path.GetFullPath(AppPaths.DataRoot);
         foreach (var root in new[] { AppPaths.LogsDirectory, Path.Combine(AppPaths.DataRoot, "debug") })
         {
-            if (!Directory.Exists(root)) continue;
-            foreach (var path in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            var fullRoot = Path.GetFullPath(root);
+            if (!Directory.Exists(fullRoot) || !IsInsideRoot(dataRoot, fullRoot)) continue;
+            try
             {
-                var fullPath = Path.GetFullPath(path);
-                if (!seen.Add(fullPath)) continue;
-                var relative = Relative(fullPath);
-                if (!relative.Contains("vision", StringComparison.OrdinalIgnoreCase)
-                    && (IsLog(relative) || IsErrorImage(relative)))
-                    yield return fullPath;
+                if ((File.GetAttributes(fullRoot) & FileAttributes.ReparsePoint) != 0)
+                {
+                    AddWarning(warnings, "discovery_root_reparse_point_skipped");
+                    continue;
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                AddWarning(warnings, $"discovery_root_attributes_failed:{ex.GetType().Name}");
+                continue;
+            }
+            pending.Push((fullRoot, fullRoot, 0));
+        }
+
+        var visitedEntries = 0;
+        while (pending.Count > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var (root, directory, depth) = pending.Pop();
+            IEnumerator<string> enumerator;
+            try
+            {
+                enumerator = Directory.EnumerateFileSystemEntries(directory).GetEnumerator();
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                AddWarning(warnings, $"discovery_open_directory_failed:{ex.GetType().Name}");
+                continue;
+            }
+            try
+            {
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    bool hasNext;
+                    try { hasNext = enumerator.MoveNext(); }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                        AddWarning(warnings, $"discovery_read_directory_failed:{ex.GetType().Name}");
+                        break;
+                    }
+                    if (!hasNext) break;
+                    if (++visitedEntries > MaxDiscoveryEntries)
+                    {
+                        AddWarning(warnings, $"discovery_entry_limit_reached:{MaxDiscoveryEntries}");
+                        yield break;
+                    }
+
+                    var path = enumerator.Current;
+                    FileAttributes attributes;
+                    try { attributes = File.GetAttributes(path); }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                        AddWarning(warnings, $"discovery_attributes_failed:{ex.GetType().Name}");
+                        continue;
+                    }
+                    if ((attributes & FileAttributes.ReparsePoint) != 0)
+                    {
+                        AddWarning(warnings, "discovery_reparse_point_skipped");
+                        continue;
+                    }
+                    if ((attributes & FileAttributes.Directory) != 0)
+                    {
+                        if (string.Equals(Path.GetFileName(path), "vision", StringComparison.OrdinalIgnoreCase))
+                            continue;
+                        if (depth >= MaxDiscoveryDepth)
+                        {
+                            AddWarning(warnings, $"discovery_depth_limit_reached:{MaxDiscoveryDepth}");
+                            continue;
+                        }
+                        var fullDirectory = Path.GetFullPath(path);
+                        if (IsInsideRoot(root, fullDirectory))
+                            pending.Push((root, fullDirectory, depth + 1));
+                        continue;
+                    }
+
+                    var fullPath = Path.GetFullPath(path);
+                    if (!IsInsideRoot(root, fullPath) || !seen.Add(fullPath)) continue;
+                    if (!IsInsideRoot(dataRoot, fullPath))
+                    {
+                        AddWarning(warnings, "discovery_outside_data_root_skipped");
+                        continue;
+                    }
+                    var relative = Relative(fullPath);
+                    if (IsLog(relative) || IsErrorImage(relative)) yield return fullPath;
+                }
+            }
+            finally
+            {
+                enumerator.Dispose();
             }
         }
     }
+
+    private static bool IsInsideRoot(string root, string path)
+    {
+        var relative = Path.GetRelativePath(root, path);
+        return !Path.IsPathRooted(relative)
+               && relative != ".."
+               && !relative.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+               && !relative.StartsWith($"..{Path.AltDirectorySeparatorChar}", StringComparison.Ordinal);
+    }
+
+    private static bool ModifiedSince(DateTime modifiedUtc, DateTime startedUtc) =>
+        modifiedUtc + MtimeTolerance >= startedUtc;
+
+    private static DateTime? TryGetLastWriteUtc(FileInfo info)
+    {
+        try { return info.LastWriteTimeUtc; }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+    }
+
+    private static void SortSlices(List<EvidenceFileSlice> slices) =>
+        slices.Sort((left, right) => StringComparer.OrdinalIgnoreCase.Compare(left.Name, right.Name));
 
     private static int GetLogPriority(string path)
     {
@@ -267,16 +725,33 @@ internal static class TaskDiagnostics
         return "other";
     }
 
-    private static DiagnosticLogBuildResult EmptyLogs(TaskEvidenceBuildStatus status) =>
-        new(status, Array.Empty<DiagnosticLogContent>(), 0, false);
+    private static DiagnosticLogBuildResult EmptyLogs(
+        TaskEvidenceBuildStatus status,
+        IReadOnlyList<string> warnings) =>
+        new(status, Array.Empty<DiagnosticLogContent>(), 0, false, warnings.ToArray());
 
-    private static ImageEvidenceBuildResult EmptyImages(TaskEvidenceBuildStatus status) =>
-        new(status, null, 0, 0);
+    private static ImageEvidenceBuildResult EmptyImages(
+        TaskEvidenceBuildStatus status,
+        IReadOnlyList<string> warnings) =>
+        new(status, null, 0, 0, 0, warnings.ToArray());
 
-    private static string Relative(string path) => Path.GetRelativePath(AppPaths.DataRoot, path).Replace('\\', '/');
-    private static bool IsLog(string path) => path.EndsWith(".log", StringComparison.OrdinalIgnoreCase) || path.Contains(".log.", StringComparison.OrdinalIgnoreCase);
-    private static bool IsErrorImage(string path) => path.Contains("/on_error/", StringComparison.OrdinalIgnoreCase)
-        && new[] { ".png", ".jpg", ".jpeg" }.Any(extension => path.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
+    internal static void AddWarning(List<string> warnings, string warning)
+    {
+        var bounded = warning.Length <= 200 ? warning : warning[..200];
+        if (warnings.Count < MaxWarnings && !warnings.Contains(bounded, StringComparer.Ordinal))
+            warnings.Add(bounded);
+    }
 
-    private sealed record LogCandidate(string Path, string Name, long Start, long Length, DateTime LastWriteUtc);
+    private static string Relative(string path) =>
+        Path.GetRelativePath(AppPaths.DataRoot, path).Replace('\\', '/');
+
+    private static bool IsLog(string path) =>
+        path.EndsWith(".log", StringComparison.OrdinalIgnoreCase)
+        || path.Contains(".log.", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsErrorImage(string path) =>
+        path.Contains("/on_error/", StringComparison.OrdinalIgnoreCase)
+        && (path.EndsWith(".png", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase));
 }

--- a/MFAAvalonia/Helper/TelemetryService.cs
+++ b/MFAAvalonia/Helper/TelemetryService.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -32,6 +33,7 @@ public static class TelemetryService
 
     private sealed class RunState
     {
+        public required string RunId { get; init; }
         public required ITransactionTracer Transaction { get; init; }
         public Dictionary<MFATask, ISpan> Tasks { get; } = new();
         public MFATask? ActiveTask { get; set; }
@@ -41,6 +43,8 @@ public static class TelemetryService
         public FailureInfo? RootFailure { get; set; }
         public FailureInfo? TerminalFailure { get; set; }
         public TaskEvidenceSnapshot? Evidence { get; set; }
+        public long EvidenceEpoch { get; set; }
+        public long? ActiveTaskId { get; set; }
         public DateTimeOffset ActiveTaskStartedAt { get; set; }
         public Dictionary<long, (long NodeId, DateTimeOffset StartedAt)> LastPipelineSteps { get; } = new();
     }
@@ -49,24 +53,38 @@ public static class TelemetryService
     {
         private readonly object _sync = new();
         private bool _captured;
+        public CancellationTokenSource Cancellation { get; } = new();
         public required SentryEvent Event { get; init; }
         public Task? Task { get; set; }
-        public bool TryCapture(SentryHint hint, Action<SentryEvent> configure)
+        public bool TryCapture(
+            SentryHint hint,
+            Action<SentryEvent> configure,
+            Action? beforeCapture = null)
         {
             lock (_sync)
             {
-                if (_captured || !IsActive) return false;
-                _captured = true;
+                if (_captured || Cancellation.IsCancellationRequested || !IsActive) return false;
                 configure(Event);
+                beforeCapture?.Invoke();
                 var eventId = SentrySdk.CaptureEvent(Event, hint, _ => { });
+                _captured = true;
                 LoggerHelper.Info($"[Telemetry] 失败事件已加入发送队列：event_id={eventId}");
                 return true;
             }
+        }
+
+        public void Cancel()
+        {
+            lock (_sync) Cancellation.Cancel();
         }
     }
 
     private const int MaxFailedNodesPerRun = 32;
     private const int MaxFailureDetailLength = 2048;
+    private const int MaxSerializedDiagnosticLogBytes = 6 * 1024;
+    private const int MaxDiagnosticLogAttributeCharacters = 200;
+    private static readonly TimeSpan ImageSettleTimeout = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan ImageSettleInterval = TimeSpan.FromMilliseconds(100);
     private static readonly object SyncRoot = new();
     private static readonly Dictionary<string, RunState> Runs = new();
     private static IDisposable? _sdk;
@@ -74,6 +92,7 @@ public static class TelemetryService
     private static readonly string AnonymousMachineId = CreateAnonymousMachineId();
     private static double FailureAttachmentSampleRate = 1.0;
     private static readonly List<PendingFailureWorker> PendingAttachmentWorkers = new();
+    private static long EvidenceEpoch;
 
     public static bool IsActive
     {
@@ -198,7 +217,7 @@ public static class TelemetryService
         if (enabled)
             InitializeFromInterface();
         else
-            Shutdown();
+            Shutdown(captureFallback: false);
     }
 
     private static void ShutdownBootstrapSdk()
@@ -448,8 +467,12 @@ public static class TelemetryService
 
         lock (SyncRoot)
         {
+            Interlocked.Increment(ref EvidenceEpoch);
             FinishRunLocked(instanceId, SpanStatus.Cancelled);
+            var runId = Guid.NewGuid().ToString("N");
             var transaction = SentrySdk.StartTransaction("mfa.task_run", "mfa.run");
+            transaction.SetData("run.id", runId);
+            transaction.SetTag("run.id", runId);
             transaction.SetData("task_count", taskNames.Count);
             if (taskNames.Count > 0)
                 transaction.SetData("tasks", string.Join(",", taskNames));
@@ -463,7 +486,12 @@ public static class TelemetryService
                 transaction.SetData("controller.type", controllerType);
                 transaction.SetTag("controller.type", controllerType);
             }
-            Runs[instanceId] = new RunState { Transaction = transaction, TaskCount = taskNames.Count };
+            Runs[instanceId] = new RunState
+            {
+                RunId = runId,
+                Transaction = transaction,
+                TaskCount = taskNames.Count
+            };
         }
     }
 
@@ -488,11 +516,21 @@ public static class TelemetryService
             run.FailedNodeCount = 0;
             run.RootFailure = null;
             run.TerminalFailure = null;
+            run.ActiveTaskId = null;
             run.LastPipelineSteps.Clear();
+            run.EvidenceEpoch = Interlocked.Increment(ref EvidenceEpoch);
             // Log collection is independent from screenshot attachment sampling.
-            run.Evidence = run.Tasks.Count == 1
-                ? TaskDiagnostics.CaptureStart(Runs.Count == 1)
-                : null;
+            try
+            {
+                run.Evidence = run.Tasks.Count == 1
+                    ? TaskDiagnostics.CaptureStart(Runs.Count == 1)
+                    : null;
+            }
+            catch (Exception ex)
+            {
+                run.Evidence = null;
+                LoggerHelper.Warning($"[Telemetry] 无法建立任务取证边界：{ex.GetType().Name}");
+            }
         }
     }
 
@@ -510,7 +548,14 @@ public static class TelemetryService
             if (status == MFATask.MFATaskStatus.FAILED || hadFailure)
             {
                 run.HasFailed = true;
-                CaptureFailureEvent(instanceId, task, span, run);
+                try
+                {
+                    CaptureFailureEvent(instanceId, task, span, run);
+                }
+                catch (Exception ex)
+                {
+                    LoggerHelper.Warning($"[Telemetry] 无法记录任务失败事件：{ex.GetType().Name}");
+                }
             }
             if (ReferenceEquals(run.ActiveTask, task))
                 run.ActiveTask = null;
@@ -527,6 +572,7 @@ public static class TelemetryService
                 return;
 
             span.SetData("task_id", taskId);
+            run.ActiveTaskId = taskId;
         }
     }
 
@@ -667,7 +713,7 @@ public static class TelemetryService
             FinishRunLocked(instanceId, ToSpanStatus(status));
     }
 
-    public static void Shutdown()
+    public static void Shutdown(bool captureFallback = true)
     {
         PendingFailureWorker[] pending;
         lock (SyncRoot)
@@ -677,21 +723,32 @@ public static class TelemetryService
             pending = PendingAttachmentWorkers.ToArray();
         }
 
+        if (!captureFallback)
+        {
+            foreach (var worker in pending) worker.Cancel();
+        }
+
         try
         {
-            Task.WaitAll(pending.Select(worker => worker.Task).Where(task => task != null).Cast<Task>().ToArray(), TimeSpan.FromSeconds(1));
+            if (captureFallback)
+                Task.WaitAll(pending.Select(worker => worker.Task).Where(task => task != null).Cast<Task>().ToArray(), TimeSpan.FromSeconds(1));
         }
         catch (AggregateException) { }
         finally
         {
-            foreach (var worker in pending.Where(worker => worker.Task is { IsCompleted: false }))
+            if (captureFallback)
             {
-                worker.TryCapture(new SentryHint(), @event =>
+                foreach (var worker in pending.Where(worker => worker.Task is { IsCompleted: false }))
                 {
-                    @event.SetExtra("attachment.status", "shutdown_timeout");
-                    @event.SetExtra("attachment.detail", "attachment worker did not finish before telemetry shutdown");
-                });
+                    worker.TryCapture(new SentryHint(), @event =>
+                    {
+                        @event.SetExtra("logs.status", "not_available");
+                        @event.SetExtra("attachment.status", "shutdown_timeout");
+                        @event.SetExtra("attachment.detail", "evidence worker did not finish before telemetry shutdown");
+                    });
+                }
             }
+            foreach (var worker in pending) worker.Cancel();
             lock (SyncRoot)
             {
                 if (_sdk != null)
@@ -795,12 +852,17 @@ public static class TelemetryService
     private static void CaptureFailureEvent(string instanceId, MFATask task, ISpan taskSpan, RunState run)
     {
         var taskName = task.SourceItem?.InterfaceItem?.Name ?? task.Name ?? "unknown-task";
-        var failureName = run.RootFailure == null
+        var rootFailure = run.RootFailure;
+        var terminalFailure = run.TerminalFailure;
+        var runId = run.RunId;
+        var taskId = run.ActiveTaskId;
+        var evidenceEpoch = run.EvidenceEpoch;
+        var failureName = rootFailure == null
             ? taskName
-            : string.IsNullOrWhiteSpace(run.RootFailure.Stage)
-                ? $"{taskName} ({run.RootFailure.Node})"
-                : $"{taskName} ({run.RootFailure.Node}/{run.RootFailure.Stage})";
-        var rootException = run.RootFailure?.Exception ?? run.TerminalFailure?.Exception;
+            : string.IsNullOrWhiteSpace(rootFailure.Stage)
+                ? $"{taskName} ({rootFailure.Node})"
+                : $"{taskName} ({rootFailure.Node}/{rootFailure.Stage})";
+        var rootException = rootFailure?.Exception ?? terminalFailure?.Exception;
         var @event = rootException == null ? new SentryEvent() : new SentryEvent(rootException);
         @event.Message = $"Maa task failed: {failureName}";
         @event.TransactionName = "mfa.task.failure";
@@ -809,14 +871,16 @@ public static class TelemetryService
             "mfa-task-failure",
             MaaProcessor.Interface?.Name ?? "unknown",
             taskName,
-            run.RootFailure?.Node ?? "terminal_failure"
+            rootFailure?.Node ?? "terminal_failure"
         };
-        if (!string.IsNullOrWhiteSpace(run.RootFailure?.Stage))
-            fingerprint.Add(run.RootFailure.Stage);
-        else if (!string.IsNullOrWhiteSpace(run.RootFailure?.Message))
-            fingerprint.Add(run.RootFailure.Message);
+        if (!string.IsNullOrWhiteSpace(rootFailure?.Stage))
+            fingerprint.Add(rootFailure.Stage);
+        else if (!string.IsNullOrWhiteSpace(rootFailure?.Message))
+            fingerprint.Add(rootFailure.Message);
         @event.Fingerprint = fingerprint.ToArray();
         @event.SetTag("task.name", taskName);
+        @event.SetTag("run.id", runId);
+        if (taskId.HasValue) @event.SetTag("task.id", taskId.Value.ToString());
         @event.SetTag("result", "failure");
         if (rootException != null)
         {
@@ -830,58 +894,91 @@ public static class TelemetryService
         @event.Contexts.Trace.Operation = taskSpan.Operation;
         @event.Contexts.Trace.Description = taskSpan.Description;
         @event.Contexts.Trace.Status = taskSpan.Status;
-        if (run.RootFailure != null)
+        if (rootFailure != null)
         {
-            SetFailureData(@event, "failure", run.RootFailure, asTags: true);
-            if (run.TerminalFailure != null && run.TerminalFailure != run.RootFailure)
-                SetFailureData(@event, "terminal_failure", run.TerminalFailure, asTags: false);
+            SetFailureData(@event, "failure", rootFailure, asTags: true);
+            if (terminalFailure != null && terminalFailure != rootFailure)
+                SetFailureData(@event, "terminal_failure", terminalFailure, asTags: false);
         }
         foreach (var option in BuildOptionSummary(task))
             @event.SetExtra($"option.{option.Key}", option.Value);
         @event.SetExtra("instance.task_count", run.TaskCount);
+        @event.SetExtra("run.id", runId);
+        if (taskId.HasValue) @event.SetExtra("task.id", taskId.Value);
         @event.SetExtra("task.duration_ms", Math.Max(0, (DateTimeOffset.UtcNow - run.ActiveTaskStartedAt).TotalMilliseconds));
         if (run.Evidence != null)
         {
             @event.SetExtra("attachment.status", "pending");
             var evidence = run.Evidence;
-            var includeImages = ShouldSampleAttachment(instanceId, taskName, FailureAttachmentSampleRate);
+            TaskEvidenceSelection selection;
+            try
+            {
+                // FinishTask holds SyncRoot here, so the next task cannot advance the
+                // evidence epoch until the terminal file generations are frozen.
+                selection = TaskDiagnostics.CaptureEnd(evidence,
+                    Runs.Count == 1 && Interlocked.Read(ref EvidenceEpoch) == evidenceEpoch);
+            }
+            catch (Exception ex)
+            {
+                @event.SetExtra("logs.status", "build_failed");
+                @event.SetExtra("attachment.status", "build_failed");
+                @event.SetExtra("attachment.detail", ex.GetType().Name);
+                var failedEventId = SentrySdk.CaptureEvent(@event, new SentryHint(), _ => { });
+                LoggerHelper.Info($"[Telemetry] 失败事件已加入发送队列：event_id={failedEventId}");
+                return;
+            }
+
+            var includeImages = ShouldSampleAttachment(runId, taskId?.ToString() ?? taskName,
+                FailureAttachmentSampleRate);
             var pendingWorker = new PendingFailureWorker { Event = @event };
             var workerTask = Task.Run(async () =>
             {
-                try
+                using (selection)
                 {
-                    // MaaFramework may still be flushing its on_error image when the failure callback arrives.
-                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
-                    var result = TaskDiagnostics.Build(evidence);
-                    CaptureDiagnosticLogs(result.Logs, @event, "task_failure", instanceId, taskName,
-                        run.RootFailure?.Node, run.RootFailure?.Stage, traceHeader.TraceId, traceHeader.SpanId);
-                    var hint = new SentryHint();
-                    if (includeImages && result.Images.Status == TaskEvidenceBuildStatus.Success && result.Images.Data != null)
+                    try
                     {
-                        hint.AddAttachment(result.Images.Data, $"mfa-task-failure-{SanitizeFileName(taskName)}-screenshots.zip",
-                            AttachmentType.Default, "application/zip");
+                        if (includeImages)
+                        {
+                            await SettleTaskImagesAsync(selection, evidenceEpoch,
+                                pendingWorker.Cancellation.Token).ConfigureAwait(false);
+                        }
+                        var result = TaskDiagnostics.Build(selection, includeImages,
+                            pendingWorker.Cancellation.Token);
+                        pendingWorker.Cancellation.Token.ThrowIfCancellationRequested();
+                        var hint = new SentryHint();
+                        if (includeImages && result.Images.Status == TaskEvidenceBuildStatus.Success && result.Images.Data != null)
+                        {
+                            hint.AddAttachment(result.Images.Data,
+                                $"mfa-task-failure-{runId}-{taskId?.ToString() ?? SanitizeFileName(taskName)}-screenshots.zip",
+                                AttachmentType.Default, "application/zip");
+                        }
+                        pendingWorker.TryCapture(hint, item =>
+                        {
+                            SetLogEvidenceData(item, result.Logs);
+                            item.SetExtra("attachment.status", !includeImages
+                                ? "not_selected"
+                                : result.Images.Status == TaskEvidenceBuildStatus.Success && result.Images.Data != null
+                                    ? "attached"
+                                    : ToAttachmentStatus(result.Images.Status));
+                            item.SetExtra("attachment.image_count", result.Images.ImageCount);
+                            item.SetExtra("attachment.selected_raw_bytes", result.Images.RawBytes);
+                            item.SetExtra("attachment.bundle_bytes", result.Images.BundleBytes);
+                            if (result.Images.Warnings.Count > 0)
+                                item.SetExtra("attachment.warnings", string.Join(",", result.Images.Warnings));
+                        }, () => CaptureDiagnosticLogs(result.Logs, @event, "task_failure",
+                            instanceId, runId, taskId, taskName, rootFailure?.Node, rootFailure?.Stage,
+                            traceHeader.TraceId, traceHeader.SpanId));
                     }
-                    pendingWorker.TryCapture(hint, item =>
+                    catch (OperationCanceledException) { }
+                    catch (Exception ex)
                     {
-                        SetLogEvidenceData(item, result.Logs);
-                        item.SetExtra("attachment.status", !includeImages
-                            ? "not_selected"
-                            : result.Images.Status == TaskEvidenceBuildStatus.Success && result.Images.Data != null
-                                ? "attached"
-                                : ToAttachmentStatus(result.Images.Status));
-                        item.SetExtra("attachment.image_count", result.Images.ImageCount);
-                        item.SetExtra("attachment.selected_raw_bytes", result.Images.RawBytes);
-                        if (includeImages && result.Images.Data != null)
-                            item.SetExtra("attachment.compressed_bytes", result.Images.Data.Length);
-                    });
-                }
-                catch (Exception ex)
-                {
-                    pendingWorker.TryCapture(new SentryHint(), item =>
-                    {
-                        item.SetExtra("attachment.status", "build_failed");
-                        item.SetExtra("attachment.detail", ex.GetType().Name);
-                    });
+                        pendingWorker.TryCapture(new SentryHint(), item =>
+                        {
+                            item.SetExtra("logs.status", "build_failed");
+                            item.SetExtra("attachment.status", "build_failed");
+                            item.SetExtra("attachment.detail", ex.GetType().Name);
+                        });
+                    }
                 }
             });
             pendingWorker.Task = workerTask;
@@ -893,9 +990,48 @@ public static class TelemetryService
             return;
         }
 
-        @event.SetExtra("attachment.status", "not_selected");
+        @event.SetExtra("logs.status", "not_available");
+        @event.SetExtra("attachment.status", "concurrent_instance");
         var eventId = SentrySdk.CaptureEvent(@event, new SentryHint(), _ => { });
         LoggerHelper.Info($"[Telemetry] 任务失败事件已加入发送队列：event_id={eventId}, task={taskName}, attachment={@event.Extra?.GetValueOrDefault("attachment.status")}");
+    }
+
+    private static async Task SettleTaskImagesAsync(
+        TaskEvidenceSelection selection,
+        long expectedEpoch,
+        CancellationToken cancellationToken)
+    {
+        if (!selection.Isolated) return;
+        var deadline = DateTimeOffset.UtcNow + ImageSettleTimeout;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Interlocked.Read(ref EvidenceEpoch) != expectedEpoch) return;
+            var remaining = deadline - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero) return;
+            await Task.Delay(remaining < ImageSettleInterval ? remaining : ImageSettleInterval,
+                cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Interlocked.Read(ref EvidenceEpoch) != expectedEpoch) return;
+
+            try
+            {
+                using var refresh = TaskDiagnostics.CaptureImageRefresh(selection, cancellationToken);
+                // A new task may have started during discovery. Never publish that scan.
+                if (Interlocked.Read(ref EvidenceEpoch) != expectedEpoch) return;
+                TaskDiagnostics.ApplyImageRefresh(selection, refresh);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                TaskDiagnostics.AddWarning(selection.Warnings,
+                    $"refresh_images_failed:{ex.GetType().Name}");
+                return;
+            }
+        }
     }
 
     private static void SetFailureData(SentryEvent @event, string prefix, FailureInfo failure, bool asTags)
@@ -932,10 +1068,10 @@ public static class TelemetryService
 
     private static string ToAttachmentStatus(TaskEvidenceBuildStatus status) => status switch
     {
-        TaskEvidenceBuildStatus.NotIsolated => "ambiguous_instance",
+        TaskEvidenceBuildStatus.ConcurrentInstance => "concurrent_instance",
         TaskEvidenceBuildStatus.NoEvidence => "no_evidence",
         TaskEvidenceBuildStatus.RawTooLarge => "raw_too_large",
-        TaskEvidenceBuildStatus.CompressedTooLarge => "compressed_too_large",
+        TaskEvidenceBuildStatus.BundleTooLarge => "bundle_too_large",
         _ => "build_failed"
     };
 
@@ -947,6 +1083,8 @@ public static class TelemetryService
         @event.SetExtra("logs.count", logs.Logs.Count);
         @event.SetExtra("logs.selected_raw_bytes", logs.RawBytes);
         @event.SetExtra("logs.truncated", logs.Truncated);
+        if (logs.Warnings.Count > 0)
+            @event.SetExtra("logs.warnings", string.Join(",", logs.Warnings));
     }
 
     private static void CaptureDiagnosticLogs(
@@ -954,6 +1092,8 @@ public static class TelemetryService
         SentryEvent @event,
         string reason,
         string? instanceId = null,
+        string? runId = null,
+        long? taskId = null,
         string? taskName = null,
         string? failureNode = null,
         string? failureStage = null,
@@ -964,30 +1104,128 @@ public static class TelemetryService
         if (result.Status != TaskEvidenceBuildStatus.Success)
             return;
 
-        const int maxChunkCharacters = 16 * 1024;
         foreach (var source in result.Logs)
         {
-            for (var offset = 0; offset < source.Content.Length; offset += maxChunkCharacters)
+            var attributes = new Dictionary<string, object>(StringComparer.Ordinal)
             {
-                var length = Math.Min(maxChunkCharacters, source.Content.Length - offset);
-                var chunk = source.Content.Substring(offset, length);
+                ["diagnostic.reason"] = BoundedLogAttribute(reason),
+                ["diagnostic.source"] = BoundedLogAttribute(source.Source),
+                ["diagnostic.kind"] = BoundedLogAttribute(source.Kind),
+                ["sentry.event_id"] = @event.EventId.ToString(),
+                ["log.raw_bytes"] = source.RawBytes
+            };
+            AddLogAttribute(attributes, "exception.source", diagnosticSource);
+            AddLogAttribute(attributes, "instance.id", instanceId);
+            AddLogAttribute(attributes, "run.id", runId);
+            if (taskId.HasValue) attributes["task.id"] = taskId.Value;
+            AddLogAttribute(attributes, "task.name", taskName);
+            AddLogAttribute(attributes, "failure.node", failureNode);
+            AddLogAttribute(attributes, "failure.stage", failureStage);
+            if (traceId.HasValue) attributes["trace.id"] = traceId.Value.ToString();
+            if (spanId.HasValue) attributes["span.id"] = spanId.Value.ToString();
+
+            var chunks = BuildDiagnosticLogChunks(source.Content, attributes);
+            for (var index = 0; index < chunks.Count; index++)
+            {
+                var chunk = chunks[index];
                 void ConfigureLog(SentryLog log)
                 {
-                    log.SetAttribute("diagnostic.reason", reason);
-                    log.SetAttribute("diagnostic.source", source.Source);
-                    log.SetAttribute("diagnostic.kind", source.Kind);
-                    if (!string.IsNullOrWhiteSpace(diagnosticSource)) log.SetAttribute("exception.source", diagnosticSource);
-                    log.SetAttribute("sentry.event_id", @event.EventId.ToString());
-                    if (!string.IsNullOrWhiteSpace(instanceId)) log.SetAttribute("instance.id", instanceId);
-                    if (!string.IsNullOrWhiteSpace(taskName)) log.SetAttribute("task.name", taskName);
-                    if (!string.IsNullOrWhiteSpace(failureNode)) log.SetAttribute("failure.node", failureNode);
-                    if (!string.IsNullOrWhiteSpace(failureStage)) log.SetAttribute("failure.stage", failureStage);
-                    if (traceId.HasValue) log.SetAttribute("trace.id", traceId.Value.ToString());
-                    if (spanId.HasValue) log.SetAttribute("span.id", spanId.Value.ToString());
+                    foreach (var attribute in attributes)
+                        log.SetAttribute(attribute.Key, attribute.Value);
+                    log.SetAttribute("log.chunk_index", index);
+                    log.SetAttribute("log.chunk_count", chunks.Count);
                 }
                 CaptureStructuredLog(GetLogLevel(chunk), ConfigureLog, chunk);
             }
         }
+    }
+
+    private static void AddLogAttribute(Dictionary<string, object> attributes, string key, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value)) attributes[key] = BoundedLogAttribute(value);
+    }
+
+    private static string BoundedLogAttribute(string value)
+    {
+        var result = new StringBuilder();
+        foreach (var rune in value.EnumerateRunes().Take(MaxDiagnosticLogAttributeCharacters))
+            result.Append((Rune.IsControl(rune) ? new Rune('\uFFFD') : rune).ToString());
+        return result.ToString();
+    }
+
+    private static IReadOnlyList<string> BuildDiagnosticLogChunks(
+        string content,
+        IReadOnlyDictionary<string, object> attributes)
+    {
+        if (content.Length == 0) return Array.Empty<string>();
+        var boundaries = new List<int> { 0 };
+        var offset = 0;
+        foreach (var rune in content.EnumerateRunes())
+        {
+            offset += rune.Utf16SequenceLength;
+            boundaries.Add(offset);
+        }
+
+        var chunks = new List<string>();
+        var startBoundary = 0;
+        while (startBoundary < boundaries.Count - 1)
+        {
+            var highBoundary = Math.Min(boundaries.Count - 1,
+                startBoundary + MaxSerializedDiagnosticLogBytes);
+            var low = startBoundary + 1;
+            var high = highBoundary;
+            var best = -1;
+            while (low <= high)
+            {
+                var middle = low + (high - low) / 2;
+                var candidate = content[boundaries[startBoundary]..boundaries[middle]];
+                if (SerializedDiagnosticLogFits(candidate, attributes))
+                {
+                    best = middle;
+                    low = middle + 1;
+                }
+                else
+                {
+                    high = middle - 1;
+                }
+            }
+            if (best < 0)
+                throw new InvalidOperationException("Bounded diagnostic attributes leave no room for one Unicode rune.");
+            chunks.Add(content[boundaries[startBoundary]..boundaries[best]]);
+            startBoundary = best;
+        }
+        return chunks;
+    }
+
+    private static bool SerializedDiagnosticLogFits(
+        string body,
+        IReadOnlyDictionary<string, object> attributes)
+    {
+        var modeledAttributes = attributes.ToDictionary(
+            item => item.Key,
+            item => (object)new
+            {
+                value = item.Value,
+                type = item.Value is string ? "string" : "integer"
+            },
+            StringComparer.Ordinal);
+        modeledAttributes["log.chunk_index"] = new { value = long.MaxValue, type = "integer" };
+        modeledAttributes["log.chunk_count"] = new { value = long.MaxValue, type = "integer" };
+        modeledAttributes["sentry.sdk.name"] = new { value = new string('s', 64), type = "string" };
+        modeledAttributes["sentry.sdk.version"] = new { value = new string('v', 32), type = "string" };
+        modeledAttributes["sentry.release"] = new { value = new string('r', 200), type = "string" };
+        modeledAttributes["sentry.environment"] = new { value = new string('e', 64), type = "string" };
+        modeledAttributes["user.id"] = new { value = new string('u', 64), type = "string" };
+        var model = new
+        {
+            timestamp = 9_999_999_999.999,
+            level = "fatal",
+            body,
+            trace_id = new string('f', 32),
+            span_id = new string('f', 16),
+            attributes = modeledAttributes
+        };
+        return JsonSerializer.SerializeToUtf8Bytes(model).Length <= MaxSerializedDiagnosticLogBytes;
     }
 
     private static void CaptureStructuredLog(SentryLogLevel level, Action<SentryLog> configure, string content)
@@ -995,19 +1233,19 @@ public static class TelemetryService
         switch (level)
         {
             case SentryLogLevel.Fatal:
-                SentrySdk.Logger.LogFatal(configure, "{0}", content);
+                SentrySdk.Logger.LogFatal(configure, content);
                 break;
             case SentryLogLevel.Error:
-                SentrySdk.Logger.LogError(configure, "{0}", content);
+                SentrySdk.Logger.LogError(configure, content);
                 break;
             case SentryLogLevel.Warning:
-                SentrySdk.Logger.LogWarning(configure, "{0}", content);
+                SentrySdk.Logger.LogWarning(configure, content);
                 break;
             case SentryLogLevel.Debug:
-                SentrySdk.Logger.LogDebug(configure, "{0}", content);
+                SentrySdk.Logger.LogDebug(configure, content);
                 break;
             default:
-                SentrySdk.Logger.LogInfo(configure, "{0}", content);
+                SentrySdk.Logger.LogInfo(configure, content);
                 break;
         }
     }
@@ -1130,12 +1368,12 @@ public static class TelemetryService
         return result;
     }
 
-    private static bool ShouldSampleAttachment(string instanceId, string taskName, double rate)
+    private static bool ShouldSampleAttachment(string runId, string taskKey, double rate)
     {
         if (rate <= 0) return false;
         if (rate >= 1) return true;
         using var sha = SHA256.Create();
-        var input = Encoding.UTF8.GetBytes($"mfa-failure-attachment-v1:{instanceId}:{taskName}");
+        var input = Encoding.UTF8.GetBytes($"mfa-failure-attachment-v1:{runId}:{taskKey}");
         var digest = sha.ComputeHash(input);
         var bucket = BitConverter.ToUInt64(digest, 0) / (double)ulong.MaxValue;
         return bucket < rate;

--- a/MFAAvalonia/Helper/TelemetryService.cs
+++ b/MFAAvalonia/Helper/TelemetryService.cs
@@ -35,7 +35,7 @@ public static class TelemetryService
     {
         public required string RunId { get; init; }
         public required ITransactionTracer Transaction { get; init; }
-        public Dictionary<MFATask, ISpan> Tasks { get; } = new();
+        public Dictionary<MFATask, TaskTelemetryState> Tasks { get; } = new();
         public MFATask? ActiveTask { get; set; }
         public bool HasFailed { get; set; }
         public int TaskCount { get; init; }
@@ -44,9 +44,14 @@ public static class TelemetryService
         public FailureInfo? TerminalFailure { get; set; }
         public TaskEvidenceSnapshot? Evidence { get; set; }
         public long EvidenceEpoch { get; set; }
-        public long? ActiveTaskId { get; set; }
-        public DateTimeOffset ActiveTaskStartedAt { get; set; }
         public Dictionary<long, (long NodeId, DateTimeOffset StartedAt)> LastPipelineSteps { get; } = new();
+    }
+
+    private sealed class TaskTelemetryState
+    {
+        public required ISpan Span { get; init; }
+        public required DateTimeOffset StartedAt { get; init; }
+        public long? TaskId { get; set; }
     }
 
     private sealed class PendingFailureWorker
@@ -510,13 +515,15 @@ public static class TelemetryService
             {
                 span.SetData($"option.{option.Key}", option.Value);
             }
-            run.Tasks[task] = span;
+            run.Tasks[task] = new TaskTelemetryState
+            {
+                Span = span,
+                StartedAt = DateTimeOffset.UtcNow
+            };
             run.ActiveTask = task;
-            run.ActiveTaskStartedAt = DateTimeOffset.UtcNow;
             run.FailedNodeCount = 0;
             run.RootFailure = null;
             run.TerminalFailure = null;
-            run.ActiveTaskId = null;
             run.LastPipelineSteps.Clear();
             run.EvidenceEpoch = Interlocked.Increment(ref EvidenceEpoch);
             // Log collection is independent from screenshot attachment sampling.
@@ -538,9 +545,10 @@ public static class TelemetryService
     {
         lock (SyncRoot)
         {
-            if (!Runs.TryGetValue(instanceId, out var run) || !run.Tasks.Remove(task, out var span))
+            if (!Runs.TryGetValue(instanceId, out var run) || !run.Tasks.Remove(task, out var taskState))
                 return;
 
+            var span = taskState.Span;
             var spanStatus = hadFailure ? SpanStatus.InternalError : ToSpanStatus(status);
             span.Status = spanStatus;
             span.SetData("result", hadFailure ? "failure" : ToResult(status));
@@ -550,7 +558,7 @@ public static class TelemetryService
                 run.HasFailed = true;
                 try
                 {
-                    CaptureFailureEvent(instanceId, task, span, run);
+                    CaptureFailureEvent(instanceId, task, taskState, run);
                 }
                 catch (Exception ex)
                 {
@@ -568,11 +576,11 @@ public static class TelemetryService
         {
             if (!Runs.TryGetValue(instanceId, out var run)
                 || run.ActiveTask == null
-                || !run.Tasks.TryGetValue(run.ActiveTask, out var span))
+                || !run.Tasks.TryGetValue(run.ActiveTask, out var taskState))
                 return;
 
-            span.SetData("task_id", taskId);
-            run.ActiveTaskId = taskId;
+            taskState.Span.SetData("task_id", taskId);
+            taskState.TaskId = taskId;
         }
     }
 
@@ -582,10 +590,11 @@ public static class TelemetryService
         {
             if (!Runs.TryGetValue(instanceId, out var run)
                 || run.ActiveTask == null
-                || !run.Tasks.TryGetValue(run.ActiveTask, out var taskSpan)
+                || !run.Tasks.TryGetValue(run.ActiveTask, out var taskState)
                 || run.FailedNodeCount++ >= MaxFailedNodesPerRun)
                 return;
 
+            var taskSpan = taskState.Span;
             var taskName = run.ActiveTask.SourceItem?.InterfaceItem?.Name ?? run.ActiveTask.Name ?? "unknown";
             var span = taskSpan.StartChild("mfa.node", string.IsNullOrWhiteSpace(nodeName) ? "unknown" : nodeName);
             span.SetData("stage", stage ?? "unknown");
@@ -626,9 +635,10 @@ public static class TelemetryService
         {
             if (!Runs.TryGetValue(instanceId, out var run)
                 || run.ActiveTask == null
-                || !run.Tasks.TryGetValue(run.ActiveTask, out var taskSpan))
+                || !run.Tasks.TryGetValue(run.ActiveTask, out var taskState))
                 return;
 
+            var taskSpan = taskState.Span;
             var failure = new FailureInfo(code, stage, null, null, null, detail, exception);
             run.RootFailure ??= failure;
             run.TerminalFailure = failure;
@@ -670,7 +680,8 @@ public static class TelemetryService
                 : null;
             var nodeName = string.IsNullOrWhiteSpace(hitNode) ? searchNode : hitNode;
             if (string.IsNullOrWhiteSpace(nodeName) || run.ActiveTask == null
-                || !run.Tasks.TryGetValue(run.ActiveTask, out var taskSpan)) return;
+                || !run.Tasks.TryGetValue(run.ActiveTask, out var taskState)) return;
+            var taskSpan = taskState.Span;
             string? stage = message.Equals("Node.PipelineNode.Failed", StringComparison.Ordinal)
                 ? string.IsNullOrWhiteSpace(hitNode) ? "recognition" : "action"
                 : null;
@@ -766,8 +777,9 @@ public static class TelemetryService
         if (!Runs.Remove(instanceId, out var run))
             return;
 
-        foreach (var span in run.Tasks.Values)
+        foreach (var taskState in run.Tasks.Values)
         {
+            var span = taskState.Span;
             span.Status = SpanStatus.Cancelled;
             span.SetData("result", "cancelled");
             span.Finish();
@@ -849,13 +861,18 @@ public static class TelemetryService
         Exception? Exception = null,
         string? Message = null);
 
-    private static void CaptureFailureEvent(string instanceId, MFATask task, ISpan taskSpan, RunState run)
+    private static void CaptureFailureEvent(
+        string instanceId,
+        MFATask task,
+        TaskTelemetryState taskState,
+        RunState run)
     {
+        var taskSpan = taskState.Span;
         var taskName = task.SourceItem?.InterfaceItem?.Name ?? task.Name ?? "unknown-task";
         var rootFailure = run.RootFailure;
         var terminalFailure = run.TerminalFailure;
         var runId = run.RunId;
-        var taskId = run.ActiveTaskId;
+        var taskId = taskState.TaskId;
         var evidenceEpoch = run.EvidenceEpoch;
         var failureName = rootFailure == null
             ? taskName
@@ -905,7 +922,8 @@ public static class TelemetryService
         @event.SetExtra("instance.task_count", run.TaskCount);
         @event.SetExtra("run.id", runId);
         if (taskId.HasValue) @event.SetExtra("task.id", taskId.Value);
-        @event.SetExtra("task.duration_ms", Math.Max(0, (DateTimeOffset.UtcNow - run.ActiveTaskStartedAt).TotalMilliseconds));
+        @event.SetExtra("task.duration_ms", Math.Max(0,
+            (DateTimeOffset.UtcNow - taskState.StartedAt).TotalMilliseconds));
         if (run.Evidence != null)
         {
             @event.SetExtra("attachment.status", "pending");


### PR DESCRIPTION
## Summary

- keep diagnostic text in Sentry Logs and reserve event attachments for failure screenshots
- freeze task-terminal file generations before asynchronous packaging so later tasks, rotations, and replacements cannot change the selected ranges
- reject evidence when any concurrent run overlaps the task, and stop late screenshot refreshes when the evidence epoch changes
- correlate transactions, failure events, structured logs, and screenshot bundles with run.id, task.id, sentry.event_id, and trace/span IDs
- make screenshot sampling independent from log capture; disabling telemetry cancels pending evidence without sending a fallback event

## Boundary controls

- logs: 1 MiB total, 512 KiB per file, 128 files; serialized structured-log records are Unicode-safe and modeled below 6 KiB
- screenshots: 5 MiB raw and 5 MiB ZIP, 128 files; PNG/JPEG data uses stored ZIP entries
- discovery: 8,192 entries, depth 16, 32 bounded warnings; reparse points and paths outside the data root are skipped
- async settle: 1 second with cancellation and task/run epoch checks
- image failures no longer suppress already-selected diagnostic logs

The existing failure_attachments_sample_rate PI field controls screenshots only. Its MaaFramework protocol proposal is tracked in MaaXYZ/MaaFramework#1461.

## Verification

- dotnet publish MFAAvalonia.Desktop/MFAAvalonia.Desktop.csproj -c Release -r win-x64
- focused local xUnit boundary harness: 5/5 passed (frozen ranges, concurrent-instance rejection, image raw limit, image failure/log independence, Unicode log chunking)
- dotnet format verification passed for both changed files
- git diff --check

Existing dependency advisory and unrelated compiler warnings remain unchanged.

## Sourcery 摘要

强化遥测失败证据边界，确保捕获的日志和屏幕截图彼此隔离、受限、可取消，并能准确关联到发起它们的任务运行。

错误修复：
- 防止并发任务运行、文件轮换、文件替换以及延迟的屏幕截图更新污染失败证据。
- 当证据捕获不再有效时，阻止遥测关闭或取消操作发出备用失败事件。

增强功能：
- 将诊断日志与屏幕截图附件分离，使遥测记录与运行、任务、事件和跟踪标识符相关联，并使屏幕截图采样独立于日志捕获。
- 添加受限且支持 Unicode 的结构化日志分块，并对日志、屏幕截图、存档、发现、警告和异步稳定过程施加限制。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过隔离、限制、关联并安全取消诊断日志和屏幕截图证据，强化任务失败遥测。

新功能：
- 将诊断日志与屏幕截图附件分离，并使用运行、任务、事件和跟踪标识符关联遥测证据。
- 使屏幕截图采样独立于诊断日志采集。

错误修复：
- 防止并发运行、文件轮换或替换，以及延迟的屏幕截图更新污染任务失败证据。
- 在遥测证据采集无效或被禁用时取消采集，且不发出备用失败事件。
- 确保图像采集失败不会丢弃已选定的诊断日志。

增强功能：
- 添加有界且支持 Unicode 的结构化日志分块，并对日志、屏幕截图、归档、文件系统发现、警告和异步稳定过程强制执行限制。
- 在异步打包前冻结证据文件范围，并在任务隔离丢失时拒绝证据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden task failure telemetry by isolating, bounding, correlating, and safely cancelling diagnostic logs and screenshot evidence.

New Features:
- Separate diagnostic logs from screenshot attachments and correlate telemetry evidence with run, task, event, and trace identifiers.
- Make screenshot sampling independent from diagnostic log capture.

Bug Fixes:
- Prevent concurrent runs, file rotations or replacements, and late screenshot updates from contaminating task failure evidence.
- Cancel invalid or disabled telemetry evidence capture without emitting fallback failure events.
- Ensure image capture failures do not discard already-selected diagnostic logs.

Enhancements:
- Add bounded, Unicode-safe structured log chunking and enforce limits for logs, screenshots, archives, filesystem discovery, warnings, and asynchronous settling.
- Freeze evidence file ranges before asynchronous packaging and reject evidence when task isolation is lost.

</details>

</details>