### PR TITLE
fix(ci): target pull requests at master

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -6,7 +6,7 @@ on:
       - 't*'
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

MFAAvalonia uses master as its GitHub default branch, but both pull-request workflows filtered for main. As a result, normal PRs targeting master did not start either cross-platform workflow automatically.

This changes only the pull_request branch filter in:

- .github/workflows/Test.yml
- .github/workflows/Release.yml

Tag and workflow_dispatch behavior, jobs, permissions, matrices, and release conditions are unchanged.

## Verification

- GitHub repository metadata reports master as the default branch
- origin has refs/heads/master and no refs/heads/main
- both workflow pull_request filters now target master
- git diff --check

Opening this PR is also the end-to-end trigger check: the two corrected pull_request workflows should register against this master-targeting PR automatically.

## Sourcery 摘要

将拉取请求 CI 工作流的目标设置为 master，使其能够针对仓库的默认分支自动运行。

错误修复：
- 修正拉取请求工作流的分支筛选条件，使测试和发布工作流能够针对以仓库 master 分支为目标的拉取请求运行。

CI：
- 将测试和发布 GitHub Actions 工作流中的 pull_request 触发器从 main 更新为 master。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Target pull-request CI workflows at master so they run automatically for the repository’s default branch.

Bug Fixes:
- Correct pull-request workflow branch filters so test and release workflows run for pull requests targeting the repository’s master branch.

CI:
- Update the pull_request triggers in the test and release GitHub Actions workflows from main to master.

</details>