### PR TITLE
feat: 新增「切换实例」特殊任务，支持多账号轮换执行

### DIFF
--- a/MFAAvalonia/Assets/Localization/Strings.en-US.resx
+++ b/MFAAvalonia/Assets/Localization/Strings.en-US.resx
@@ -1939,6 +1939,9 @@ Please do not copy only the main executable by itself.</value>
     <data name="SpecialTask_Webhook" xml:space="preserve">
         <value>Webhook</value>
     </data>
+    <data name="SpecialTask_SwitchInstance" xml:space="preserve">
+        <value>Switch Instance</value>
+    </data>
     <data name="SpecialTask_CountdownDesc" xml:space="preserve">
         <value>Continues to the next task after the specified seconds, supports `1~86400` seconds (24 hours), useful for adding delays between tasks.</value>
     </data>
@@ -1960,8 +1963,14 @@ Please do not copy only the main executable by itself.</value>
     <data name="SpecialTask_WebhookDesc" xml:space="preserve">
         <value>Sends an HTTP request to a specified URL with custom request body, useful for integrating with external services or automation platforms.</value>
     </data>
+    <data name="SpecialTask_SwitchInstanceDesc" xml:space="preserve">
+        <value>Stops the current instance, switches to the target instance (optionally itself), reconnects the emulator, and starts the target queue. Useful for multi-account rotation or single-instance looping.</value>
+    </data>
     <data name="SpecialTask_CountdownSeconds" xml:space="preserve">
         <value>Countdown (seconds)</value>
+    </data>
+    <data name="SpecialTask_SwitchInstanceTarget" xml:space="preserve">
+        <value>Target Instance</value>
     </data>
     <data name="SpecialTask_WaitUntilTime" xml:space="preserve">
         <value>Wait until (HH:MM)</value>

--- a/MFAAvalonia/Assets/Localization/Strings.ja-JP.resx
+++ b/MFAAvalonia/Assets/Localization/Strings.ja-JP.resx
@@ -412,6 +412,9 @@
   <data name="SpecialTask_Webhook" xml:space="preserve">
     <value>Webhook</value>
   </data>
+  <data name="SpecialTask_SwitchInstance" xml:space="preserve">
+    <value>インスタンス切替</value>
+  </data>
   <data name="SpecialTask_CountdownDesc" xml:space="preserve">
     <value>一定時間カウントダウンしてから次の処理を実行します。</value>
   </data>
@@ -433,8 +436,14 @@
   <data name="SpecialTask_WebhookDesc" xml:space="preserve">
     <value>指定した URL に Webhook リクエストを送信します。</value>
   </data>
+  <data name="SpecialTask_SwitchInstanceDesc" xml:space="preserve">
+    <value>現在のインスタンスのタスクを停止し、対象インスタンス（自分自身も可）に切り替えてエミュレーターを再接続し、対象のタスクを開始します。複数アカウントのローテーションや単一インスタンスのループ実行に使用します。</value>
+  </data>
   <data name="SpecialTask_CountdownSeconds" xml:space="preserve">
     <value>カウントダウン秒数</value>
+  </data>
+  <data name="SpecialTask_SwitchInstanceTarget" xml:space="preserve">
+    <value>対象インスタンス</value>
   </data>
   <data name="SpecialTask_WaitUntilTime" xml:space="preserve">
     <value>待機終了時刻</value>

--- a/MFAAvalonia/Assets/Localization/Strings.resx
+++ b/MFAAvalonia/Assets/Localization/Strings.resx
@@ -1949,6 +1949,9 @@
     <data name="SpecialTask_Webhook" xml:space="preserve">
         <value>Webhook</value>
     </data>
+    <data name="SpecialTask_SwitchInstance" xml:space="preserve">
+        <value>切换实例</value>
+    </data>
     <data name="SpecialTask_CountdownDesc" xml:space="preserve">
         <value>在指定的秒数后继续执行下一个任务，支持 `1~86400` 秒（24小时），可用于任务之间的延迟等待。</value>
     </data>
@@ -1970,8 +1973,14 @@
     <data name="SpecialTask_WebhookDesc" xml:space="preserve">
         <value>发送 HTTP 请求到指定 URL，支持 `GET`/`POST` 方法，可自定义请求体和 Content-Type。</value>
     </data>
+    <data name="SpecialTask_SwitchInstanceDesc" xml:space="preserve">
+        <value>停止当前实例任务，切换到目标实例（可为自己）并重新连接模拟器后启动目标任务，用于多账号轮换或单实例循环执行。</value>
+    </data>
     <data name="SpecialTask_CountdownSeconds" xml:space="preserve">
         <value>倒计时（秒）</value>
+    </data>
+    <data name="SpecialTask_SwitchInstanceTarget" xml:space="preserve">
+        <value>目标实例</value>
     </data>
     <data name="SpecialTask_WaitUntilTime" xml:space="preserve">
         <value>等待到（时:分）</value>

--- a/MFAAvalonia/Assets/Localization/Strings.zh-Hant.resx
+++ b/MFAAvalonia/Assets/Localization/Strings.zh-Hant.resx
@@ -1939,6 +1939,9 @@
     <data name="SpecialTask_Webhook" xml:space="preserve">
         <value>Webhook</value>
     </data>
+    <data name="SpecialTask_SwitchInstance" xml:space="preserve">
+        <value>切換實例</value>
+    </data>
     <data name="SpecialTask_CountdownDesc" xml:space="preserve">
         <value>在指定的秒數後繼續執行下一個任務，支援 `1~86400` 秒（24小時），可用於任務之間的延遲等待。</value>
     </data>
@@ -1960,8 +1963,14 @@
     <data name="SpecialTask_WebhookDesc" xml:space="preserve">
         <value>向指定 URL 發送 HTTP 請求，支援自訂請求體，適用於與外部服務或自動化平台整合。</value>
     </data>
+    <data name="SpecialTask_SwitchInstanceDesc" xml:space="preserve">
+        <value>停止目前實例任務，切換到目標實例（可為自己）並重新連線模擬器後啟動目標任務，用於多帳號輪換或單實例循環執行。</value>
+    </data>
     <data name="SpecialTask_CountdownSeconds" xml:space="preserve">
         <value>倒計時（秒）</value>
+    </data>
+    <data name="SpecialTask_SwitchInstanceTarget" xml:space="preserve">
+        <value>目標實例</value>
     </data>
     <data name="SpecialTask_WaitUntilTime" xml:space="preserve">
         <value>等待到（時:分）</value>

--- a/MFAAvalonia/Extensions/MaaFW/Custom/SwitchInstanceAction.cs
+++ b/MFAAvalonia/Extensions/MaaFW/Custom/SwitchInstanceAction.cs
@@ -28,6 +28,7 @@ public class SwitchInstanceAction : IMaaCustomAction
 
     public bool Run<T>(T context, in RunArgs args, in RunResults results) where T : IMaaContext
     {
+        var acquired = false;
         try
         {
             var json = ActionParamHelper.Parse(args.ActionParam);
@@ -46,6 +47,7 @@ public class SwitchInstanceAction : IMaaCustomAction
                 Fail("已有切换实例正在进行，本次请求已忽略");
                 return false;
             }
+            acquired = true;
 
             LoggerHelper.Info($"[SwitchInstanceAction] 切换实例：{_owner.InstanceId} -> {targetId}");
 
@@ -58,6 +60,8 @@ public class SwitchInstanceAction : IMaaCustomAction
         }
         catch (Exception e)
         {
+            if (acquired)
+                Interlocked.Exchange(ref _switching, 0);
             LoggerHelper.Error($"[SwitchInstanceAction] Error: {e.Message}");
             return false;
         }
@@ -97,6 +101,13 @@ public class SwitchInstanceAction : IMaaCustomAction
                     if (Instances.TryGetResolved<InstanceTabBarViewModel>(out var tabBar) && tabBar != null)
                         tabBar.SwitchToInstanceById(targetId);
                 });
+            }
+
+            // 目标实例正在运行则跳过启动，避免打断其任务。
+            if (target.IsTaskRunActive)
+            {
+                LoggerHelper.Info($"[SwitchInstanceAction] 目标实例 {targetId} 正在运行，已跳过启动");
+                return;
             }
 
             // 断开旧连接，保证 Start 时“重新连接”模拟器（而非复用已连接状态）。

--- a/MFAAvalonia/Extensions/MaaFW/Custom/SwitchInstanceAction.cs
+++ b/MFAAvalonia/Extensions/MaaFW/Custom/SwitchInstanceAction.cs
@@ -1,0 +1,133 @@
+using MaaFramework.Binding;
+using MaaFramework.Binding.Custom;
+using MFAAvalonia.Helper;
+using MFAAvalonia.Helper.ValueType;
+using MFAAvalonia.ViewModels.Other;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MFAAvalonia.Extensions.MaaFW.Custom;
+
+/// <summary>
+/// 特殊任务「切换实例」：停止当前实例任务，切换到目标实例（可为自己），重新连接模拟器并启动目标队列。
+/// 目标实例通过 custom_action_param 的 target_instance 指定（实例名或 ID）。
+/// </summary>
+public class SwitchInstanceAction : IMaaCustomAction
+{
+    /// <summary>全局单飞行标志：同一时刻只允许一次切换，避免多个实例同时触发接力。</summary>
+    private static int _switching;
+
+    /// <summary>当前 action 所属实例（运行本任务的那个实例）。</summary>
+    private readonly MaaProcessor _owner;
+
+    public string Name { get; set; } = nameof(SwitchInstanceAction);
+
+    public SwitchInstanceAction(MaaProcessor owner) => _owner = owner;
+
+    public bool Run<T>(T context, in RunArgs args, in RunResults results) where T : IMaaContext
+    {
+        try
+        {
+            var json = ActionParamHelper.Parse(args.ActionParam);
+            var target = (string?)json["target_instance"] ?? string.Empty;
+
+            var targetId = MaaProcessorManager.Instance.ResolveInstanceId(target);
+            if (targetId == null)
+            {
+                Fail($"目标实例不存在：{target}");
+                return false;
+            }
+
+            // 单飞行：已在切换中则拒绝本次请求。
+            if (Interlocked.CompareExchange(ref _switching, 1, 0) != 0)
+            {
+                Fail("已有切换实例正在进行，本次请求已忽略");
+                return false;
+            }
+
+            LoggerHelper.Info($"[SwitchInstanceAction] 切换实例：{_owner.InstanceId} -> {targetId}");
+
+            // 立即请求停止当前实例（异步排队），使“切换实例”之后的本实例任务尽快终止。
+            _owner.Stop(MFATask.MFATaskStatus.STOPPED);
+
+            // 切换、重连、启动等耗时操作放到后台，避免阻塞本任务的 native 回调。
+            _ = Task.Run(() => SwitchAsync(_owner, targetId));
+            return true;
+        }
+        catch (Exception e)
+        {
+            LoggerHelper.Error($"[SwitchInstanceAction] Error: {e.Message}");
+            return false;
+        }
+    }
+
+    private static async Task SwitchAsync(MaaProcessor from, string targetId)
+    {
+        try
+        {
+            // 等当前实例真正停稳，避免切换后其连接/截图回调仍指向旧实例。
+            if (!await WaitIdleAsync(from, TimeSpan.FromSeconds(15)))
+            {
+                LoggerHelper.Warning("[SwitchInstanceAction] 等待当前实例停止超时，放弃切换");
+                return;
+            }
+
+            var self = string.Equals(targetId, from.InstanceId, StringComparison.OrdinalIgnoreCase);
+            MaaProcessor target;
+            if (self)
+            {
+                target = from;
+            }
+            else
+            {
+                // 目标实例可能尚未被懒加载，先确保其已加载。
+                MaaProcessorManager.Instance.EnsureInstanceLoaded(targetId);
+                if (!MaaProcessorManager.Instance.TryGetInstance(targetId, out var loaded))
+                {
+                    LoggerHelper.Warning($"[SwitchInstanceAction] 目标实例加载失败：{targetId}");
+                    return;
+                }
+                target = loaded;
+
+                MaaProcessorManager.Instance.SwitchCurrent(targetId);
+                DispatcherHelper.PostOnMainThread(() =>
+                {
+                    if (Instances.TryGetResolved<InstanceTabBarViewModel>(out var tabBar) && tabBar != null)
+                        tabBar.SwitchToInstanceById(targetId);
+                });
+            }
+
+            // 断开旧连接，保证 Start 时“重新连接”模拟器（而非复用已连接状态）。
+            target.SetTasker();
+            target.Start();
+        }
+        catch (Exception ex)
+        {
+            LoggerHelper.Error($"[SwitchInstanceAction] 切换失败：{ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _switching, 0);
+        }
+    }
+
+    private static async Task<bool> WaitIdleAsync(MaaProcessor processor, TimeSpan timeout)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (!processor.IsTaskRunActive && processor.TaskQueue.Count == 0)
+                return true;
+            await Task.Delay(100);
+        }
+        return false;
+    }
+
+    private void Fail(string message)
+    {
+        LoggerHelper.Error($"[SwitchInstanceAction] {message}");
+        _owner.AddLog($"[切换实例] {message}");
+    }
+}

--- a/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
@@ -4866,6 +4866,7 @@ public class MaaProcessor
             tasker.Resource.Register(new Custom.ComputerOperationAction());
             tasker.Resource.Register(new Custom.WebhookAction());
             tasker.Resource.Register(new Custom.HeiLiuAction((content, color) => AddLog(content, color)));
+            tasker.Resource.Register(new Custom.SwitchInstanceAction(this));
             LoggerHelper.Info("已注册内置特殊任务动作。");
 
             // 获取当前资源的自定义目录

--- a/MFAAvalonia/Helper/LangKeys.cs
+++ b/MFAAvalonia/Helper/LangKeys.cs
@@ -654,6 +654,7 @@ public static class LangKeys
 	public static readonly string SpecialTask_KillProcess = "SpecialTask_KillProcess";
 	public static readonly string SpecialTask_ComputerOperation = "SpecialTask_ComputerOperation";
 	public static readonly string SpecialTask_Webhook = "SpecialTask_Webhook";
+	public static readonly string SpecialTask_SwitchInstance = "SpecialTask_SwitchInstance";
 	public static readonly string SpecialTask_CountdownDesc = "SpecialTask_CountdownDesc";
 	public static readonly string SpecialTask_TimedWaitDesc = "SpecialTask_TimedWaitDesc";
 	public static readonly string SpecialTask_ToastDesc = "SpecialTask_ToastDesc";
@@ -661,7 +662,9 @@ public static class LangKeys
 	public static readonly string SpecialTask_KillProcessDesc = "SpecialTask_KillProcessDesc";
 	public static readonly string SpecialTask_ComputerOperationDesc = "SpecialTask_ComputerOperationDesc";
 	public static readonly string SpecialTask_WebhookDesc = "SpecialTask_WebhookDesc";
+	public static readonly string SpecialTask_SwitchInstanceDesc = "SpecialTask_SwitchInstanceDesc";
 	public static readonly string SpecialTask_CountdownSeconds = "SpecialTask_CountdownSeconds";
+	public static readonly string SpecialTask_SwitchInstanceTarget = "SpecialTask_SwitchInstanceTarget";
 	public static readonly string SpecialTask_WaitUntilTime = "SpecialTask_WaitUntilTime";
 	public static readonly string SpecialTask_NotificationTitle = "SpecialTask_NotificationTitle";
 	public static readonly string SpecialTask_NotificationContent = "SpecialTask_NotificationContent";

--- a/MFAAvalonia/Helper/TaskOptionGenerator.cs
+++ b/MFAAvalonia/Helper/TaskOptionGenerator.cs
@@ -1327,6 +1327,9 @@ public class TaskOptionGenerator(TaskQueueViewModel viewModel, Action saveConfig
             case "WebhookAction":
                 AddWebhookOptions(panel, dragItem);
                 break;
+            case "SwitchInstanceAction":
+                AddSwitchInstanceOptions(panel, dragItem);
+                break;
         }
     }
 
@@ -1364,6 +1367,52 @@ public class TaskOptionGenerator(TaskQueueViewModel viewModel, Action saveConfig
         Grid.SetColumn(numericUpDown, 1);
         AddResponsiveBehavior(grid, label, numericUpDown);
         grid.Children.Add(numericUpDown);
+        panel.Children.Add(grid);
+    }
+
+    /// <summary>
+    /// 切换实例 - 目标实例下拉选择（含自己，用于单实例循环）
+    /// </summary>
+    private void AddSwitchInstanceOptions(StackPanel panel, DragItemViewModel dragItem)
+    {
+        var param = GetActionParam(dragItem);
+        var grid = CreateSpecialTaskGrid(isFirstRow: true);
+
+        var label = CreateLabelPanel(LangKeys.SpecialTask_SwitchInstanceTarget, null, null, useI18n: true);
+        Grid.SetColumn(label, 0);
+        grid.Children.Add(label);
+
+        var instances = MaaProcessorManager.Instance.GetAllInstanceIdsAndNames();
+        var names = instances.Select(i => i.Name).ToList();
+
+        var comboBox = new ComboBox
+        {
+            MinWidth = 120,
+            Margin = new Thickness(0, 2, 0, 2),
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Classes = { "TaskOptionLikeCombo" },
+            ItemsSource = names,
+        };
+        BindIdleEnabled(comboBox);
+
+        var current = (string?)param["target_instance"];
+        var currentIndex = string.IsNullOrWhiteSpace(current)
+            ? -1
+            : instances.FindIndex(i => i.Name == current || i.Id == current);
+        if (currentIndex >= 0)
+            comboBox.SelectedIndex = currentIndex;
+
+        comboBox.SelectionChanged += (_, _) =>
+        {
+            if (comboBox.SelectedIndex < 0 || comboBox.SelectedIndex >= names.Count) return;
+            param["target_instance"] = names[comboBox.SelectedIndex];
+            UpdateActionParam(dragItem, param);
+        };
+
+        Grid.SetColumn(comboBox, 1);
+        AddResponsiveBehavior(grid, label, comboBox);
+        grid.Children.Add(comboBox);
         panel.Children.Add(grid);
     }
 

--- a/MFAAvalonia/ViewModels/UsersControls/AddTaskDialogViewModel.cs
+++ b/MFAAvalonia/ViewModels/UsersControls/AddTaskDialogViewModel.cs
@@ -33,6 +33,7 @@ public partial class AddTaskDialogViewModel : ViewModelBase, IDisposable
         "KillProcessAction",
         "ComputerOperationAction",
         "WebhookAction",
+        "SwitchInstanceAction",
     };
 
     private ObservableCollection<AddTaskItemViewModel> _items;
@@ -73,6 +74,7 @@ public partial class AddTaskDialogViewModel : ViewModelBase, IDisposable
             new() { Name = LangKeys.SpecialTask_KillProcess.ToLocalization(), IsSpecialTask = true, SpecialActionName = "KillProcessAction", SpecialIcon = "⛔" },
             new() { Name = LangKeys.SpecialTask_ComputerOperation.ToLocalization(), IsSpecialTask = true, SpecialActionName = "ComputerOperationAction", SpecialIcon = "⚡" },
             new() { Name = LangKeys.SpecialTask_Webhook.ToLocalization(), IsSpecialTask = true, SpecialActionName = "WebhookAction", SpecialIcon = "🔔" },
+            new() { Name = LangKeys.SpecialTask_SwitchInstance.ToLocalization(), IsSpecialTask = true, SpecialActionName = "SwitchInstanceAction", SpecialIcon = "🔁" },
         };
 
         LanguageHelper.LanguageChanged += OnLanguageChanged;
@@ -160,6 +162,7 @@ public partial class AddTaskDialogViewModel : ViewModelBase, IDisposable
             "KillProcessAction" => new JObject { ["kill_self_process"] = true, ["process_name"] = "" },
             "ComputerOperationAction" => new JObject { ["operation"] = "shutdown" },
             "WebhookAction" => new JObject { ["url"] = "", ["method"] = "GET", ["body"] = "", ["content_type"] = "application/json" },
+            "SwitchInstanceAction" => new JObject { ["target_instance"] = "" },
             _ => new JObject()
         };
     }
@@ -209,6 +212,7 @@ public partial class AddTaskDialogViewModel : ViewModelBase, IDisposable
             "KillProcessAction" => LangKeys.SpecialTask_KillProcessDesc,
             "ComputerOperationAction" => LangKeys.SpecialTask_ComputerOperationDesc,
             "WebhookAction" => LangKeys.SpecialTask_WebhookDesc,
+            "SwitchInstanceAction" => LangKeys.SpecialTask_SwitchInstanceDesc,
             _ => LangKeys.SpecialTask
         };
     }


### PR DESCRIPTION
## 需求

支持多账号轮换执行任务：账号 1 执行完自动切换到账号 2，账号 2 完成后切账号 3，以此类推（可循环）。

## 实现

新增特殊任务「切换实例」（与倒计时、自定义程序等特殊任务同级），在任务参数中填写目标实例名称。运行到该任务时依次：停止当前实例 → 切换到目标实例 → 重新连接模拟器 → 启动目标任务队列。目标通过 `custom_action_param.target_instance` 指定（实例名或 ID）。

## 特性

- 支持切到自己：目标填自己时，停止 → 重连 → 重启本实例，实现单实例循环执行。
- 参数 UI 提供目标实例下拉选择，复用现有特殊任务参数面板。

## 边界处理

- 目标实例正在运行 → 跳过启动，不打断其任务；
- 当前实例停不干净（15s 超时）→ 放弃切换；
- 并发切换 → 单飞行标志拒绝重复请求；
- 目标实例未懒加载 → 自动 `EnsureInstanceLoaded`。

## 改动

- 新增 `SwitchInstanceAction`（特殊任务 + 接力编排）
- 注册到 `MaaProcessor` 的 custom action
- `AddTaskDialogViewModel` / `TaskOptionGenerator` 暴露为可添加的特殊任务
- 本地化 zh / zh-Hant / en-US / ja-JP

## Sourcery 摘要

通过可配置的特殊任务在不同模拟器实例之间切换，从而支持链式或循环执行任务。

新功能：
- 添加“切换实例”特殊任务，以便在已配置的账户之间交接执行，或重启当前实例以实现循环工作流。

增强功能：
- 协调实例停止、加载、重新连接和任务启动流程，同时避免中断已在运行的目标实例，以及避免重复的并发切换。

杂项：
- 在任务创建和配置界面中提供新的特殊任务，并支持本地化标签及所有受支持语言下的目标实例选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable chained or looping task execution by switching between emulator instances through a configurable special task.

New Features:
- Add the “Switch Instance” special task to hand off execution between configured accounts or restart the current instance for looping workflows.

Enhancements:
- Coordinate instance stopping, loading, reconnection, and task startup while avoiding interruption of already-running target instances and duplicate concurrent switches.

Chores:
- Expose the new special task in task creation and configuration UI with localized labels and target-instance selection across supported languages.

</details>