### PR TITLE
feat: 流水线化实时视图截图，adb 监控可突破 30fps

### DIFF
--- a/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
@@ -1158,6 +1158,7 @@ public class MaaProcessor
 
     private void DisposeScreenshotTasker()
     {
+        ResetLiveViewScreencapJob();
         DetachScreenshotTasker(requireStopped: true);
     }
 
@@ -1265,6 +1266,89 @@ public class MaaProcessor
             LoggerHelper.Warning($"提交截图任务失败：{ex.Message}");
             return MaaJobStatus.Invalid;
         }
+    }
+
+    /// <summary>
+    /// 实时视图在途截图任务（流水线复用，非阻塞）。
+    /// </summary>
+    private MaaJob? _liveViewScreencapJob;
+
+    /// <summary>
+    /// 流水线式提交实时视图截图：非阻塞，提交后立即返回，截图由控制器在后台执行。
+    /// 若上一帧截图仍在执行则复用而不重复提交，避免任务堆积。
+    /// 相比原 PostScreencap 的同步 Screencap().Wait()，定时器不再被截图耗时阻塞，
+    /// 实时视图刷新率可真正由 LiveViewRefreshRate 决定。
+    /// </summary>
+    /// <returns>null 表示控制器不可用；Succeeded 表示已提交或仍有正常在途截图；
+    /// Failed/Invalid 表示上一帧截图失败（与 PostScreencap 的失败语义一致）。</returns>
+    public MaaJobStatus? PostScreencapPipelined()
+    {
+        var controller = GetScreenshotController(false);
+        if (controller == null)
+        {
+            return MaaJobStatus.Invalid;
+        }
+
+        if (!controller.IsConnected)
+        {
+            return IsAnyScreenshotRelatedWorkRunning(controller)
+                ? MaaJobStatus.Succeeded
+                : MaaJobStatus.Invalid;
+        }
+
+        var job = Volatile.Read(ref _liveViewScreencapJob);
+        if (job != null)
+        {
+            MaaJobStatus status;
+            try
+            {
+                status = job.Status;
+            }
+            catch (ObjectDisposedException)
+            {
+                // 任务器已重建，放弃旧的在途任务
+                Volatile.Write(ref _liveViewScreencapJob, null);
+                return MaaJobStatus.Invalid;
+            }
+            catch
+            {
+                Volatile.Write(ref _liveViewScreencapJob, null);
+                return MaaJobStatus.Invalid;
+            }
+
+            if (status.IsRunning() || status.IsPending())
+            {
+                // 上一帧仍在执行，保持流水线复用，不重复提交
+                return MaaJobStatus.Succeeded;
+            }
+
+            // 上一帧已结束：若失败，先向调用方上报（仅一次），随后替换为新的在途任务
+            Volatile.Write(ref _liveViewScreencapJob, null);
+            if (status is MaaJobStatus.Failed or MaaJobStatus.Invalid)
+            {
+                return status;
+            }
+        }
+
+        try
+        {
+            Volatile.Write(ref _liveViewScreencapJob, controller.Screencap());
+            return MaaJobStatus.Succeeded;
+        }
+        catch (Exception ex)
+        {
+            LoggerHelper.Warning($"提交截图任务失败：{ex.Message}");
+            Volatile.Write(ref _liveViewScreencapJob, null);
+            return MaaJobStatus.Invalid;
+        }
+    }
+
+    /// <summary>
+    /// 实时视图流水线清理：放弃在途截图任务（截图任务器重建/断开时调用）。
+    /// </summary>
+    public void ResetLiveViewScreencapJob()
+    {
+        Volatile.Write(ref _liveViewScreencapJob, null);
     }
 
     public bool IsMainControllerConnected()

--- a/MFAAvalonia/ViewModels/Pages/TaskQueueViewModel.cs
+++ b/MFAAvalonia/ViewModels/Pages/TaskQueueViewModel.cs
@@ -3269,10 +3269,14 @@ public partial class TaskQueueViewModel : ViewModelBase, IDisposable
                 return;
             if (EnableLiveView && IsConnected)
             {
-                var status = Processor.PostScreencap();
-                if (status != MaaJobStatus.Succeeded)
+                // 流水线：非阻塞提交下一帧截图（若上一帧仍在执行则复用，避免任务堆积），
+                // 随后读取最近完成的一帧进行显示。相比原来的同步 Screencap().Wait()，
+                // 定时器不再被截图耗时阻塞，实际刷新率可真正由 LiveViewRefreshRate 决定。
+                // 返回值为上一帧的失败终态（Failed/Invalid）时走既有恢复逻辑（连续失败达阈值才重建/断开）。
+                var status = Processor.PostScreencapPipelined();
+                if (status is MaaJobStatus.Failed or MaaJobStatus.Invalid)
                 {
-                    if (Processor.HandleScreencapStatus(status))
+                    if (Processor.HandleScreencapStatus(status.Value))
                     {
                         if (Processor.IsMainControllerConnected())
                         {
@@ -3288,7 +3292,6 @@ public partial class TaskQueueViewModel : ViewModelBase, IDisposable
                             });
                         }
                     }
-                    return;
                 }
 
                 var buffer = Processor.GetLiveViewBuffer(false);
@@ -3305,11 +3308,12 @@ public partial class TaskQueueViewModel : ViewModelBase, IDisposable
                         LoggerHelper.Warning($"实时画面为空：截图方式={screencapType}，控制器={controllerType}，原因={reason}");
                         AddLog($"warn: {LangKeys.LiveViewNoImageWarning.ToLocalizationFormatted(false, screencapType, reason)}", (IBrush?)null);
                     }
-                    return;
                 }
-
-                _liveViewNoImageLogged = false;
-                _ = UpdateLiveViewImageAsync(buffer);
+                else
+                {
+                    _liveViewNoImageLogged = false;
+                    _ = UpdateLiveViewImageAsync(buffer);
+                }
             }
             else
             {


### PR DESCRIPTION
## 背景

实时视图（Live View）的 adb 监控默认只能跑到约 30fps，即使把「实时视图最高刷新率」拉到 120 也上不去。

**根因**：每次定时器触发都走同步阻塞链路 —— `controller.Screencap().Wait()` 会一直等到整帧截图从设备传回才返回，而 `_liveViewTickInProgress` 防重入又让定时器在这期间不再触发。于是实际帧率 = 1 ÷ (一帧截图耗时)，与配置的 FPS 无关。PNG `screencap -p` 一帧 50~100ms，实测就只有 10~20fps。

## 改动

把实时视图截图改为**流水线（非阻塞）**：每个 tick 先异步提交下一帧（不等待，毫秒级返回），再读取最近完成的一帧进行显示。定时器不再被截图耗时阻塞，实际刷新率由「配置的 FPS」和「截图方式能产出的帧率」两者中的较小值决定。

### `MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs`
- 新增实时视图在途截图任务字段 `_liveViewScreencapJob`，以及：
  - `PostScreencapPipelined()`：非阻塞提交一帧截图；若上一帧仍在执行则复用不叠加；上一帧以 `Failed/Invalid` 结束时上报一次，与原有失败语义一致
  - `ResetLiveViewScreencapJob()`：截图任务器重建时清理在途任务（挂在 `DisposeScreenshotTasker()` 中）
- 失败恢复逻辑（连续失败达阈值 → 重建截图任务器 / 断开）保持不变

### `MFAAvalonia/ViewModels/Pages/TaskQueueViewModel.cs`
- `OnLiveViewTimerElapsed` 改用 `PostScreencapPipelined()` 非阻塞提交，再读最近完成帧显示；失败检测改为非阻塞轮询上一帧终态

## 使用提示

- FPS 设置只是「请求上限」，真正的瓶颈在**截图方式**：默认自动检测常选中较慢的 PNG `screencap`。模拟器建议在「连接设置 → 截图方式」选择 `MinicapStream`（模拟器首选）或 `RawByNetcat`（真机）
- 模拟器/游戏自身渲染帧率若锁定 30fps，截图也无法突破该上限

## 验证

- 编译通过（Debug / net10.0，0 错误）
- 实时视图窗口显示的实测 FPS 数字即为生效值

## Sourcery 摘要

将实时视图截图更新为流水线式非阻塞处理，以提升刷新性能并保持失败恢复机制。

新功能：
- 将实时视图截图改为非阻塞流水线处理，以提升高刷新率配置下的实际帧率。

错误修复：
- 避免同步截图耗时阻塞实时视图定时器，并保持截图失败恢复行为。

改进：
- 复用在途截图任务，并在截图任务器重建或断开时清理任务，防止任务堆积。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将实时视图截图更新为流水线式非阻塞处理，以提升刷新性能并保持失败恢复机制。

New Features:
- 将实时视图截图改为非阻塞流水线处理，以提升高刷新率配置下的实际帧率。

Bug Fixes:
- 避免同步截图耗时阻塞实时视图定时器，并保持截图失败恢复行为。

Enhancements:
- 复用在途截图任务并在截图任务器重建或断开时清理任务，防止任务堆积。

</details>