### PR TITLE
fix: 修复实时视图失败帧与截图任务竞争问题

### DIFF
--- a/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
@@ -1286,7 +1286,7 @@ public class MaaProcessor
         var controller = GetScreenshotController(false);
         if (controller == null)
         {
-            return MaaJobStatus.Invalid;
+            return null;
         }
 
         if (!controller.IsConnected)

--- a/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
@@ -1299,6 +1299,12 @@ public class MaaProcessor
 
         if (!controller.IsConnected)
         {
+            if (screenshotTaskerGeneration != Volatile.Read(ref _screenshotTaskerGeneration))
+            {
+                // The tasker was detached while resolving its controller.
+                return null;
+            }
+
             return IsAnyScreenshotRelatedWorkRunning(controller)
                 ? MaaJobStatus.Succeeded
                 : MaaJobStatus.Invalid;

--- a/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
@@ -736,6 +736,13 @@ public class MaaProcessor
             _screenshotTasker = null;
             initTask = _screenshotTaskerInitTask;
             _screenshotTaskerInitTask = null;
+
+            // Publish the new generation and drop the old job under the same job
+            // lock used by PostScreencapPipelined to prevent republishing a stale job.
+            lock (_liveViewScreencapJobLock)
+            {
+                _liveViewScreencapJob = null;
+            }
         }
 
         if (!requireStopped)
@@ -1158,7 +1165,6 @@ public class MaaProcessor
 
     private void DisposeScreenshotTasker()
     {
-        ResetLiveViewScreencapJob();
         DetachScreenshotTasker(requireStopped: true);
     }
 
@@ -1272,6 +1278,7 @@ public class MaaProcessor
     /// 实时视图在途截图任务（流水线复用，非阻塞）。
     /// </summary>
     private MaaJob? _liveViewScreencapJob;
+    private readonly Lock _liveViewScreencapJobLock = new();
 
     /// <summary>
     /// 流水线式提交实时视图截图：非阻塞，提交后立即返回，截图由控制器在后台执行。
@@ -1283,6 +1290,7 @@ public class MaaProcessor
     /// Failed/Invalid 表示上一帧截图失败（与 PostScreencap 的失败语义一致）。</returns>
     public MaaJobStatus? PostScreencapPipelined()
     {
+        var screenshotTaskerGeneration = Volatile.Read(ref _screenshotTaskerGeneration);
         var controller = GetScreenshotController(false);
         if (controller == null)
         {
@@ -1296,50 +1304,59 @@ public class MaaProcessor
                 : MaaJobStatus.Invalid;
         }
 
-        var job = Volatile.Read(ref _liveViewScreencapJob);
-        if (job != null)
+        lock (_liveViewScreencapJobLock)
         {
-            MaaJobStatus status;
+            if (screenshotTaskerGeneration != Volatile.Read(ref _screenshotTaskerGeneration))
+            {
+                // The tasker was detached while resolving its controller.
+                return null;
+            }
+
+            var job = _liveViewScreencapJob;
+            if (job != null)
+            {
+                MaaJobStatus status;
+                try
+                {
+                    status = job.Status;
+                }
+                catch (ObjectDisposedException)
+                {
+                    // 任务器已重建，放弃旧的在途任务
+                    _liveViewScreencapJob = null;
+                    return MaaJobStatus.Invalid;
+                }
+                catch
+                {
+                    _liveViewScreencapJob = null;
+                    return MaaJobStatus.Invalid;
+                }
+
+                if (status.IsRunning() || status.IsPending())
+                {
+                    // 上一帧仍在执行，保持流水线复用，不重复提交
+                    return MaaJobStatus.Succeeded;
+                }
+
+                // 上一帧已结束：若失败，先向调用方上报（仅一次），随后替换为新的在途任务
+                _liveViewScreencapJob = null;
+                if (status is MaaJobStatus.Failed or MaaJobStatus.Invalid)
+                {
+                    return status;
+                }
+            }
+
             try
             {
-                status = job.Status;
-            }
-            catch (ObjectDisposedException)
-            {
-                // 任务器已重建，放弃旧的在途任务
-                Volatile.Write(ref _liveViewScreencapJob, null);
-                return MaaJobStatus.Invalid;
-            }
-            catch
-            {
-                Volatile.Write(ref _liveViewScreencapJob, null);
-                return MaaJobStatus.Invalid;
-            }
-
-            if (status.IsRunning() || status.IsPending())
-            {
-                // 上一帧仍在执行，保持流水线复用，不重复提交
+                _liveViewScreencapJob = controller.Screencap();
                 return MaaJobStatus.Succeeded;
             }
-
-            // 上一帧已结束：若失败，先向调用方上报（仅一次），随后替换为新的在途任务
-            Volatile.Write(ref _liveViewScreencapJob, null);
-            if (status is MaaJobStatus.Failed or MaaJobStatus.Invalid)
+            catch (Exception ex)
             {
-                return status;
+                LoggerHelper.Warning($"提交截图任务失败：{ex.Message}");
+                _liveViewScreencapJob = null;
+                return MaaJobStatus.Invalid;
             }
-        }
-
-        try
-        {
-            Volatile.Write(ref _liveViewScreencapJob, controller.Screencap());
-            return MaaJobStatus.Succeeded;
-        }
-        catch (Exception ex)
-        {
-            LoggerHelper.Warning($"提交截图任务失败：{ex.Message}");
-            Volatile.Write(ref _liveViewScreencapJob, null);
-            return MaaJobStatus.Invalid;
         }
     }
 
@@ -1348,7 +1365,10 @@ public class MaaProcessor
     /// </summary>
     public void ResetLiveViewScreencapJob()
     {
-        Volatile.Write(ref _liveViewScreencapJob, null);
+        lock (_liveViewScreencapJobLock)
+        {
+            _liveViewScreencapJob = null;
+        }
     }
 
     public bool IsMainControllerConnected()

--- a/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
+++ b/MFAAvalonia/Extensions/MaaFW/MaaProcessor.cs
@@ -1286,7 +1286,7 @@ public class MaaProcessor
     /// 相比原 PostScreencap 的同步 Screencap().Wait()，定时器不再被截图耗时阻塞，
     /// 实时视图刷新率可真正由 LiveViewRefreshRate 决定。
     /// </summary>
-    /// <returns>null 表示控制器不可用；Succeeded 表示已提交或仍有正常在途截图；
+    /// <returns>null 表示控制器不可用或截图任务器已切换；Succeeded 表示已提交或仍有正常在途截图；
     /// Failed/Invalid 表示上一帧截图失败（与 PostScreencap 的失败语义一致）。</returns>
     public MaaJobStatus? PostScreencapPipelined()
     {
@@ -1361,7 +1361,7 @@ public class MaaProcessor
     }
 
     /// <summary>
-    /// 实时视图流水线清理：放弃在途截图任务（截图任务器重建/断开时调用）。
+    /// 实时视图流水线清理：放弃在途截图任务。截图任务器分离时也会在代际变更下清空在途任务。
     /// </summary>
     public void ResetLiveViewScreencapJob()
     {

--- a/MFAAvalonia/ViewModels/Pages/TaskQueueViewModel.cs
+++ b/MFAAvalonia/ViewModels/Pages/TaskQueueViewModel.cs
@@ -3314,6 +3314,7 @@ public partial class TaskQueueViewModel : ViewModelBase, IDisposable
                             });
                         }
                     }
+                    return;
                 }
 
                 var buffer = Processor.GetLiveViewBuffer(false);


### PR DESCRIPTION
## 背景

实时视图（Live View）在截图失败后仍可能显示上一帧的过期画面，且截图任务提交与截图任务器分离之间存在竞态，可能把已分离任务器的陈旧任务重新发布到新控制器上。

## 修改

- `ce1439f` fix: align live view controller status contract
  - `PostScreencapPipelined` 在控制器不可用或截图任务器已切换时返回 `null`，不再误报 `Invalid`，避免任务器尚未就绪时触发不必要的重建/断开逻辑。

- `d5382a3` fix: sync live view screencap job generation
  - 引入代际（generation）与 `_liveViewScreencapJobLock`，在提交截图任务时校验任务器代际，并在任务器分离时同步清空在途任务，防止把陈旧任务重新发布到新控制器。

- `6440037` fix: skip stale live view frame after failure
  - 截图失败后直接返回，跳过本次对已缓存/过期帧的显示，避免截图失败时画面停留在旧帧上造成误导。

- `b717efc` docs: clarify live view null status meaning
  - 补充 `null` 返回值的文档说明。

## 验证

- `dotnet build MFAAvalonia/MFAAvalonia.csproj -c Debug --no-restore` 通过。
- 未新增编译警告。

## Sourcery 总结

防止在任务器更改和截图失败期间发生实时视图截图竞态以及显示过时帧。

错误修复：
- 防止在截图任务器分离或替换后，重新发布过时的实时视图截图作业。
- 避免在实时视图截图失败后显示缓存帧。
- 当实时视图控制器不可用或已发生变化时，返回 null 状态，而不是报告无效的截图结果。

增强功能：
- 将实时视图截图作业生命周期与任务器代际同步，以消除提交和分离竞态。

文档：
- 明确说明，管道化截图状态为 null 表示截图任务器不可用或已发生变化。

<details>
<summary>Original summary in English</summary>

## Sourcery 生成的摘要

防止在截图任务器发生更改或失败期间出现实时视图截图竞态和过时帧显示。

错误修复：
- 防止在截图任务器分离或替换后重新发布过时的实时视图截图任务。
- 避免在实时视图截图失败后显示缓存帧。
- 当截图控制器不可用或在提交期间发生变化时，返回空的管道状态。

增强功能：
- 将实时视图截图任务的生命周期与任务器代际同步，以消除提交和分离竞态。

文档：
- 明确说明，空的管道截图状态表示截图任务器不可用或已发生变化。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

防止实时视图截图竞争问题，以及在截图任务器发生更改或失败期间显示过时帧。

Bug 修复：
- 防止在截图任务器分离或替换后重新发布过时的实时视图截图任务。
- 避免在实时视图截图失败后显示缓存帧。
- 当截图控制器不可用或在提交期间发生更改时，返回空的管道状态。

增强功能：
- 将实时视图截图任务处理与任务器代际同步，以消除提交与分离之间的竞争问题。

文档：
- 说明管道化截图状态为空表示截图任务器不可用或已发生更改。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent live-view screenshot races and stale frame display during screenshot tasker changes or failures.

Bug Fixes:
- Prevent stale live-view screenshot jobs from being republished after the screenshot tasker is detached or replaced.
- Avoid displaying cached frames after a live-view screenshot failure.
- Return a null pipeline status when the screenshot controller is unavailable or changes during submission.

Enhancements:
- Synchronize live-view screenshot job handling with tasker generations to eliminate submission and detachment races.

Documentation:
- Clarify that a null pipelined screenshot status indicates an unavailable or changed screenshot tasker.

</details>

</details>

</details>